### PR TITLE
Implemented Pick-Command and a helper called "EmptySlotKeeperHack"

### DIFF
--- a/src/main/java/net/wurstclient/command/CmdList.java
+++ b/src/main/java/net/wurstclient/command/CmdList.java
@@ -44,6 +44,7 @@ public final class CmdList
 	public final LeaveCmd leaveCmd = new LeaveCmd();
 	public final ModifyCmd modifyCmd = new ModifyCmd();
 	public final PathCmd pathCmd = new PathCmd();
+	public final PickCmd pickCmd = new PickCmd();
 	public final PotionCmd potionCmd = new PotionCmd();
 	public final ProtectCmd protectCmd = new ProtectCmd();
 	public final RenameCmd renameCmd = new RenameCmd();

--- a/src/main/java/net/wurstclient/commands/PickCmd.java
+++ b/src/main/java/net/wurstclient/commands/PickCmd.java
@@ -1,0 +1,116 @@
+package net.wurstclient.commands;
+
+import net.minecraft.item.Item;
+import net.minecraft.util.registry.Registry;
+import net.wurstclient.command.CmdException;
+import net.wurstclient.command.CmdSyntaxError;
+import net.wurstclient.command.Command;
+import net.wurstclient.util.MathUtils;
+
+import java.util.*;
+
+import static net.wurstclient.util.InventoryUtils.isHotbarSlot;
+
+public class PickCmd extends Command
+{
+    public PickCmd()
+    {
+        super("pick",
+                "Picks the given item from your inventory\n" +
+                        "to the hotbar slot of your choice.\n" +
+                        "Requires 1 empty slot in your inventory and\n" +
+                        "a filled hotbar.\n" +
+                        "Use EmptySlotKeeper-Hack to automatically keep\n" +
+                        "1 slot empty.",
+                ".pick <item> <hotbar-slot>");
+    }
+
+    @Override
+    public void call(String[] args) throws CmdException
+    {
+        if(args.length != 2)
+            throw new CmdSyntaxError("Expected 2 arguments");
+
+        Integer slot;
+        String item = args[0];
+
+        if(!MathUtils.isInteger(args[1]))
+            throw new CmdSyntaxError("Slot has to be a number .");
+
+        slot = Integer.parseInt(args[1]);
+
+        if (!isHotbarSlot(slot))
+            throw new CmdSyntaxError("Slot must be a number between 1 and 9.");
+
+        slot--; //fix index to start at 0
+        equipItem(item, slot);
+    }
+
+    private void equipItem(String item, Integer slot)
+    {
+        if(equipFromHotbar(item, slot))
+        {
+            return;
+        }
+        else
+        {
+            equipFromInventory(item, slot);
+        }
+    }
+
+    private void equipFromInventory(String item, int slot)
+    {
+        // search potion in inventory
+        int itemInInventory = findItem(9, 36,item );
+
+        if(itemInInventory == -1)
+            return;
+
+        swapFromInventoryToHotbar(itemInInventory, slot);
+    }
+
+    private boolean equipFromHotbar(String item, int slot)
+    {
+        int itemInHotbar = findItem(0, 9, item);
+
+        // check if any item was found
+        if (itemInHotbar == -1)
+            return false;
+
+        //Currently the specified slot in which the item should be placed is ignored for hotbar items.
+        //To fix this, you need to swap/click items in the hotbar. Unfortunately i wasn't able to code it.
+        MC.player.inventory.selectedSlot = itemInHotbar;
+
+        return true;
+    }
+
+    private void swapFromInventoryToHotbar(int from, int to)
+    {
+        if(from == -1)
+            return;
+
+        MC.player.inventory.selectedSlot = to;
+
+        //1. move the item from the hotbar which is blocking the specified slot to your inventory (requires 1 empty space)
+        IMC.getInteractionManager()
+                .windowClick_QUICK_MOVE(to + 36);
+
+        //2. move the target item from your inventory to the empty hotbar slot (all other hotbar slots must be filled)
+        if (to != -1)
+            IMC.getInteractionManager()
+                    .windowClick_QUICK_MOVE(from);
+    }
+
+    private int findItem(int startSlot, int endSlot, String itemName)
+    {
+        for(int i = startSlot; i < endSlot; i++)
+        {
+            Item currentItem = MC.player.inventory.getInvStack(i).getItem();
+            String currentItemName = Registry.ITEM.getId(currentItem).toString();
+            if(Objects.equals(itemName, currentItemName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -71,6 +71,7 @@ public final class HackList implements UpdateListener
 	public final CriticalsHack criticalsHack = new CriticalsHack();
 	public final DerpHack derpHack = new DerpHack();
 	public final DolphinHack dolphinHack = new DolphinHack();
+	public final EmptySlotKeeperHack emptySlotKeeperHack = new EmptySlotKeeperHack();
 	public final ExcavatorHack excavatorHack = new ExcavatorHack();
 	public final ExtraElytraHack extraElytraHack = new ExtraElytraHack();
 	public final FancyChatHack fancyChatHack = new FancyChatHack();

--- a/src/main/java/net/wurstclient/hacks/EmptySlotKeeperHack.java
+++ b/src/main/java/net/wurstclient/hacks/EmptySlotKeeperHack.java
@@ -1,0 +1,88 @@
+package net.wurstclient.hacks;
+
+import net.wurstclient.SearchTags;
+import net.wurstclient.events.UpdateListener;
+import net.wurstclient.hack.Hack;
+import net.wurstclient.util.ChatUtils;
+
+import static net.wurstclient.util.InventoryUtils.getAdjustedInventorySlot;
+
+@SearchTags({"inventory", "empty", "slot", "pick"})
+public class EmptySlotKeeperHack extends Hack implements UpdateListener
+{
+    public EmptySlotKeeperHack()
+    {
+        super("EmptySlotKeeper", "Keeps one slot of your inventory always empty.\n" +
+                "Useful in combination with the pick-command.");
+    }
+
+    @Override
+    public void onEnable()
+    {
+        disabledOnStartup = true;
+        showRemoveItemMessage = true;
+        EVENTS.add(UpdateListener.class, this);
+    }
+
+    @Override
+    public void onDisable()
+    {
+        EVENTS.remove(UpdateListener.class, this);
+    }
+
+    private int lastEmptySlot = -1;
+    private boolean disabledOnStartup;
+    private boolean showRemoveItemMessage;
+
+    private void keepOneSlotEmpty()
+    {
+        if(isInventoryFull())
+        {
+            //throw last picked up item away
+            IMC.getInteractionManager().windowClick_THROW(getAdjustedInventorySlot(lastEmptySlot));
+        }
+    }
+
+    private boolean isInventoryFull(){
+        int slot = MC.player.inventory.getEmptySlot();
+
+        //no empty slot was found
+        if(slot == -1)
+            return true;
+
+        lastEmptySlot = slot;
+        return false;
+    }
+
+    @Override
+    public void onUpdate()
+    {
+        if(disabledOnStartup)
+        {
+            checkInventoryBeforeStart();
+        }
+        else
+        {
+            keepOneSlotEmpty();
+        }
+    }
+
+    private void checkInventoryBeforeStart()
+    {
+        //Forces the user to remove one item of choice if the inventory is full after enabling
+        if(isInventoryFull())
+        {
+            if(showRemoveItemMessage)
+            {
+                ChatUtils.warning("Please remove one item from your inventory before the EmptySlotKeeper can start.");
+                showRemoveItemMessage = false;
+            }
+
+            return;
+        }
+        else
+        {
+            disabledOnStartup = false;
+        }
+    }
+}

--- a/src/main/java/net/wurstclient/util/InventoryUtils.java
+++ b/src/main/java/net/wurstclient/util/InventoryUtils.java
@@ -1,0 +1,16 @@
+package net.wurstclient.util;
+
+public enum InventoryUtils
+{
+    ;
+
+    public static int getAdjustedInventorySlot(int slot)
+    {
+        return isHotbarSlot(slot) ? slot + 36 : slot;
+    }
+
+    public static boolean isHotbarSlot(int slot)
+    {
+        return slot >= 0 && slot <= 8;
+    }
+}


### PR DESCRIPTION
## Original PR #96

## Description
[aBinaryStory ](https://github.com/aBinaryStory/Wurst7-1/):
PickCmd:

On use, it searches the inventory for the given item and places it to the specified hotbar slot.
It can be combined with .bind command f.e. to always equip the Diamond Sword to hotbar slot 1 when button x is pressed. (Binding items to keys)
it uses the Minecraft concept of Quick Move Items, which allowes items from the inventory to be moved to the hotbar using one click/button and vice versa.
Limitations:
To Quick Move Items, you need at least one empty slot in your inventory. To automatically keep one slot empty, i created the EmptySlootKeeperHack
items can not be placed to the specifed slot, if the hotbar is not filled. (Randomly places the item in the hotbar and switches to it)
EmptySlootKeeperHack:

On enabled, it will always drop the last picked item if your inventory is full.
-> Keeps always one inventory slot empty
