### PR TITLE
Pr 96 a binary story pick item command

### DIFF
--- a/src/main/java/net/wurstclient/command/CmdList.java
+++ b/src/main/java/net/wurstclient/command/CmdList.java
@@ -47,7 +47,7 @@ public final class CmdList
 	public final LeaveCmd leaveCmd = new LeaveCmd();
 	public final ModifyCmd modifyCmd = new ModifyCmd();
 	public final PathCmd pathCmd = new PathCmd();
-	public final PickCmd pickCmd = new PickCmd();
+	public final EquipCmd equipCmd = new EquipCmd();
 	public final PotionCmd potionCmd = new PotionCmd();
 	public final ProtectCmd protectCmd = new ProtectCmd();
 	public final RenameCmd renameCmd = new RenameCmd();

--- a/src/main/java/net/wurstclient/commands/EquipCmd.java
+++ b/src/main/java/net/wurstclient/commands/EquipCmd.java
@@ -5,25 +5,24 @@ import net.minecraft.util.registry.Registry;
 import net.wurstclient.command.CmdException;
 import net.wurstclient.command.CmdSyntaxError;
 import net.wurstclient.command.Command;
-import net.wurstclient.util.ChatUtils;
 import net.wurstclient.util.MathUtils;
 
 import java.util.*;
 
 import static net.wurstclient.util.InventoryUtils.isHotbarSlot;
 
-public class PickCmd extends Command
+public class EquipCmd extends Command
 {
-    public PickCmd()
+    public EquipCmd()
     {
-        super("pick",
-                "Picks the given item from your inventory\n" +
+        super("equip",
+                "Equips the given item from your inventory\n" +
                         "to the hotbar slot of your choice.\n" +
                         "Requires 1 empty slot in your inventory and\n" +
                         "a filled hotbar.\n" +
                         "Use EmptySlotKeeper-Hack to automatically keep\n" +
                         "1 slot empty.",
-                ".pick <item> <hotbar-slot>");
+                ".equip <item-minecraft-id> <hotbar-slot>");
     }
 
     @Override

--- a/src/main/java/net/wurstclient/commands/PickCmd.java
+++ b/src/main/java/net/wurstclient/commands/PickCmd.java
@@ -5,6 +5,7 @@ import net.minecraft.util.registry.Registry;
 import net.wurstclient.command.CmdException;
 import net.wurstclient.command.CmdSyntaxError;
 import net.wurstclient.command.Command;
+import net.wurstclient.util.ChatUtils;
 import net.wurstclient.util.MathUtils;
 
 import java.util.*;
@@ -31,7 +32,7 @@ public class PickCmd extends Command
         if(args.length != 2)
             throw new CmdSyntaxError("Expected 2 arguments");
 
-        Integer slot;
+        int slot;
         String item = args[0];
 
         if(!MathUtils.isInteger(args[1]))
@@ -48,11 +49,7 @@ public class PickCmd extends Command
 
     private void equipItem(String item, Integer slot)
     {
-        if(equipFromHotbar(item, slot))
-        {
-            return;
-        }
-        else
+        if(!equipFromHotbar(item, slot))
         {
             equipFromInventory(item, slot);
         }
@@ -79,7 +76,7 @@ public class PickCmd extends Command
 
         //Currently the specified slot in which the item should be placed is ignored for hotbar items.
         //To fix this, you need to swap/click items in the hotbar. Unfortunately i wasn't able to code it.
-        MC.player.inventory.selectedSlot = itemInHotbar;
+        MC.player.getInventory().selectedSlot = itemInHotbar;
 
         return true;
     }
@@ -89,7 +86,7 @@ public class PickCmd extends Command
         if(from == -1)
             return;
 
-        MC.player.inventory.selectedSlot = to;
+        MC.player.getInventory().selectedSlot = to;
 
         //1. move the item from the hotbar which is blocking the specified slot to your inventory (requires 1 empty space)
         IMC.getInteractionManager()
@@ -105,7 +102,7 @@ public class PickCmd extends Command
     {
         for(int i = startSlot; i < endSlot; i++)
         {
-            Item currentItem = MC.player.inventory.getInvStack(i).getItem();
+            Item currentItem = MC.player.getInventory().getStack(i).getItem();
             String currentItemName = Registry.ITEM.getId(currentItem).toString();
             if(Objects.equals(itemName, currentItemName)) {
                 return i;

--- a/src/main/java/net/wurstclient/hacks/EmptySlotKeeperHack.java
+++ b/src/main/java/net/wurstclient/hacks/EmptySlotKeeperHack.java
@@ -12,8 +12,7 @@ public class EmptySlotKeeperHack extends Hack implements UpdateListener
 {
     public EmptySlotKeeperHack()
     {
-        super("EmptySlotKeeper", "Keeps one slot of your inventory always empty.\n" +
-                "Useful in combination with the pick-command.");
+        super("EmptySlotKeeper");
     }
 
     @Override
@@ -44,7 +43,7 @@ public class EmptySlotKeeperHack extends Hack implements UpdateListener
     }
 
     private boolean isInventoryFull(){
-        int slot = MC.player.inventory.getEmptySlot();
+        int slot = MC.player.getInventory().getEmptySlot();
 
         //no empty slot was found
         if(slot == -1)
@@ -77,8 +76,6 @@ public class EmptySlotKeeperHack extends Hack implements UpdateListener
                 ChatUtils.warning("Please remove one item from your inventory before the EmptySlotKeeper can start.");
                 showRemoveItemMessage = false;
             }
-
-            return;
         }
         else
         {

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -51,6 +51,7 @@
   "description.wurst.hack.crystalaura": "Automatically places (optional) and detonates end crystals to kill entities around you.",
   "description.wurst.hack.derp": "Randomly moves your head around.\nOnly visible to other players.",
   "description.wurst.hack.dolphin": "Makes you bob up in water automatically.\n(just like a dolphin)",
+  "description.wurst.hack.emptyslotkeeper": "Keeps one slot of your inventory always empty.\n Useful in combination with the pick-command.",
   "description.wurst.hack.excavator": "Automatically breaks all blocks in the selected area.",
   "description.wurst.hack.extraelytra": "Makes the Elytra easier to use.",
   "description.wurst.hack.fancychat": "Replaces ASCII characters in sent chat messages with fancier unicode characters. Can be used to bypass curse word filters on some servers.\nDoes not work on servers that block unicode characters.",


### PR DESCRIPTION
## Original PR #96

## Description
[aBinaryStory ](https://github.com/aBinaryStory/Wurst7-1/):
PickCmd:

On use, it searches the inventory for the given item and places it to the specified hotbar slot.
It can be combined with .bind command f.e. to always equip the Diamond Sword to hotbar slot 1 when button x is pressed. (Binding items to keys)
it uses the Minecraft concept of Quick Move Items, which allowes items from the inventory to be moved to the hotbar using one click/button and vice versa.
Limitations:
To Quick Move Items, you need at least one empty slot in your inventory. To automatically keep one slot empty, i created the EmptySlootKeeperHack
items can not be placed to the specifed slot, if the hotbar is not filled. (Randomly places the item in the hotbar and switches to it)
EmptySlootKeeperHack:

On enabled, it will always drop the last picked item if your inventory is full.
-> Keeps always one inventory slot empty
## NOTES:
I changed the .pick command name to .equip
