### PR TITLE
Xray legit mode

### DIFF
--- a/src/main/java/net/wurstclient/events/ShouldDrawSideListener.java
+++ b/src/main/java/net/wurstclient/events/ShouldDrawSideListener.java
@@ -10,6 +10,8 @@ package net.wurstclient.events;
 import java.util.ArrayList;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.wurstclient.event.Event;
 import net.wurstclient.event.Listener;
 
@@ -21,16 +23,23 @@ public interface ShouldDrawSideListener extends Listener
 		extends Event<ShouldDrawSideListener>
 	{
 		private final BlockState state;
+		private final BlockPos pos;
 		private Boolean rendered;
 		
-		public ShouldDrawSideEvent(BlockState state)
+		public ShouldDrawSideEvent(BlockState state, BlockPos pos)
 		{
 			this.state = state;
+			this.pos = pos;
 		}
-		
+
 		public BlockState getState()
 		{
 			return state;
+		}
+
+		public BlockPos getPos()
+		{
+			return pos;
 		}
 		
 		public Boolean isRendered()

--- a/src/main/java/net/wurstclient/events/TesselateBlockListener.java
+++ b/src/main/java/net/wurstclient/events/TesselateBlockListener.java
@@ -10,6 +10,7 @@ package net.wurstclient.events;
 import java.util.ArrayList;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
 import net.wurstclient.event.CancellableEvent;
 import net.wurstclient.event.Listener;
 
@@ -21,15 +22,22 @@ public interface TesselateBlockListener extends Listener
 		extends CancellableEvent<TesselateBlockListener>
 	{
 		private final BlockState state;
+		private final BlockPos pos;
 		
-		public TesselateBlockEvent(BlockState state)
+		public TesselateBlockEvent(BlockState state, BlockPos pos)
 		{
 			this.state = state;
+			this.pos = pos;
 		}
 		
 		public BlockState getState()
 		{
 			return state;
+		}
+
+		public BlockPos getPos()
+		{
+			return pos;
 		}
 		
 		@Override

--- a/src/main/java/net/wurstclient/hacks/XRayHack.java
+++ b/src/main/java/net/wurstclient/hacks/XRayHack.java
@@ -33,11 +33,11 @@ public final class XRayHack extends Hack implements UpdateListener,
 	ShouldDrawSideListener, TesselateBlockListener, RenderBlockEntityListener
 {
 	private final CheckboxSetting legitMode = new CheckboxSetting("Legit mode",
-			"Only reveals blocks that can be legitimately seen,\n"
-			        + "where at least one side is next to a non-solid block.\n\n"
-					+ "Can be used to bypass anti-xray plugins like Orebfuscator\n"
-					+ "which replace fully concealed blocks with random ores.",
-			false);
+		"Only reveals blocks that can be legitimately seen,\n"
+				+ "where at least one side is next to a non-solid block.\n\n"
+				+ "Can be used to bypass anti-xray plugins like Orebfuscator\n"
+				+ "which replace fully concealed blocks with random ores.",
+		false);
 
 	private final BlockListSetting ores = new BlockListSetting("Ores", "",
 		"minecraft:ancient_debris", "minecraft:anvil", "minecraft:beacon",

--- a/src/main/java/net/wurstclient/mixin/BlockMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockMixin.java
@@ -33,7 +33,7 @@ public abstract class BlockMixin implements ItemConvertible
 	private static void onShouldDrawSide(BlockState state, BlockView blockView,
 		BlockPos blockPos, Direction side, CallbackInfoReturnable<Boolean> cir)
 	{
-		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state);
+		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, blockPos);
 		EventManager.fire(event);
 		
 		if(event.isRendered() != null)

--- a/src/main/java/net/wurstclient/mixin/BlockModelRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/BlockModelRendererMixin.java
@@ -40,7 +40,7 @@ public abstract class BlockModelRendererMixin
 		boolean depthTest, Random random_1, long long_1, int int_1,
 		CallbackInfoReturnable<Boolean> cir)
 	{
-		TesselateBlockEvent event = new TesselateBlockEvent(blockState_1);
+		TesselateBlockEvent event = new TesselateBlockEvent(blockState_1, blockPos_1);
 		EventManager.fire(event);
 		
 		if(event.isCancelled())
@@ -52,7 +52,7 @@ public abstract class BlockModelRendererMixin
 		if(!depthTest)
 			return;
 		
-		ShouldDrawSideEvent event2 = new ShouldDrawSideEvent(blockState_1);
+		ShouldDrawSideEvent event2 = new ShouldDrawSideEvent(blockState_1, blockPos_1);
 		EventManager.fire(event2);
 		if(!Boolean.TRUE.equals(event2.isRendered()))
 			return;

--- a/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
+++ b/src/main/java/net/wurstclient/mixin/FluidRendererMixin.java
@@ -32,7 +32,7 @@ public class FluidRendererMixin
 		CallbackInfoReturnable<Boolean> cir)
 	{
 		BlockState state = blockView_1.getBlockState(blockPos_1);
-		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state);
+		ShouldDrawSideEvent event = new ShouldDrawSideEvent(state, blockPos_1);
 		EventManager.fire(event);
 		
 		if(event.isRendered() != null)

--- a/src/main/java/net/wurstclient/mixin/TerrainRenderContextMixin.java
+++ b/src/main/java/net/wurstclient/mixin/TerrainRenderContextMixin.java
@@ -31,7 +31,7 @@ public class TerrainRenderContextMixin
 		final BakedModel model, MatrixStack matrixStack,
 		CallbackInfoReturnable<Boolean> cir)
 	{
-		TesselateBlockEvent event = new TesselateBlockEvent(blockState);
+		TesselateBlockEvent event = new TesselateBlockEvent(blockState, blockPos);
 		EventManager.fire(event);
 		
 		if(event.isCancelled())


### PR DESCRIPTION
## Original PR #297

## Description
[bo3tools](https://github.com/bo3tools/Wurst7/):
I've noticed that most ore obfuscator implementations only obfuscate blocks that are fully concealed, e.g covered in opaque blocks from all sides. This pull request adds a "Legit mode" option to the X-Ray hack that only shows naturally visible blocks that you can obtain without extra information, like ore exposed in the sides of a cave wall.

