### PR TITLE
improve recognition of untranslated text

### DIFF
--- a/src/main/java/net/wurstclient/util/GoogleTranslate.java
+++ b/src/main/java/net/wurstclient/util/GoogleTranslate.java
@@ -27,7 +27,8 @@ public class GoogleTranslate
 		String html = getHTML(text, langFrom, langTo);
 		String translated = parseHTML(html);
 		
-		if(text.equalsIgnoreCase(translated))
+		if(text.replaceAll("\\s", "").equalsIgnoreCase(
+			translated.replaceAll("\\s", "")))
 			return null;
 		
 		return translated;


### PR DESCRIPTION
## Original PR #477

## Description
[pcm1k](https://github.com/pcm1k/Wurst7/):
Make ChatTranslatorHack properly handle whitespace when comparing untranslated text, and translated text. Google Translate sometimes likes to insert, or delete whitespace randomly. So I think simply ignoring whitespace should be fine, and fix this issue.
