### PR TITLE
Refactor match hacks

### DIFF
--- a/src/main/java/net/wurstclient/clickgui/ClickGui.java
+++ b/src/main/java/net/wurstclient/clickgui/ClickGui.java
@@ -51,7 +51,9 @@ public final class ClickGui
 	private final ArrayList<Window> windows = new ArrayList<>();
 	private final ArrayList<Popup> popups = new ArrayList<>();
 	private final Path windowsFile;
-	
+
+	private float[] rainbowColor = new float[3];
+
 	private float[] bgColor = new float[3];
 	private float[] acColor = new float[3];
 	private int txtColor;
@@ -605,19 +607,22 @@ public final class ClickGui
 	public void updateColors()
 	{
 		ClickGuiHack clickGui = WURST.getHax().clickGuiHack;
-		
+
 		opacity = clickGui.getOpacity();
 		ttOpacity = clickGui.getTooltipOpacity();
 		bgColor = clickGui.getBackgroundColor();
 		txtColor = clickGui.getTextColor();
+
+		float x = System.currentTimeMillis() % 2000 / 1000F;
+		rainbowColor[0] = 0.5F + 0.5F * (float)Math.sin(x * Math.PI);
+		rainbowColor[1] = 0.5F + 0.5F * (float)Math.sin((x + 4F / 3F) * Math.PI);
+		rainbowColor[2] = 0.5F + 0.5F * (float)Math.sin((x + 8F / 3F) * Math.PI);
 		
 		if(WurstClient.INSTANCE.getHax().rainbowUiHack.isEnabled())
 		{
-			float x = System.currentTimeMillis() % 2000 / 1000F;
-			acColor[0] = 0.5F + 0.5F * (float)Math.sin(x * Math.PI);
-			acColor[1] = 0.5F + 0.5F * (float)Math.sin((x + 4F / 3F) * Math.PI);
-			acColor[2] = 0.5F + 0.5F * (float)Math.sin((x + 8F / 3F) * Math.PI);
-			
+			acColor[0] = rainbowColor[0];
+			acColor[1] = rainbowColor[1];
+			acColor[2] = rainbowColor[2];
 		}else
 			acColor = clickGui.getAccentColor();
 	}
@@ -1210,7 +1215,12 @@ public final class ClickGui
 		bufferBuilder.end();
 		BufferRenderer.draw(bufferBuilder);
 	}
-	
+
+	public float[] getRainbowColor()
+	{
+		return rainbowColor;
+	}
+
 	public float[] getBgColor()
 	{
 		return bgColor;

--- a/src/main/java/net/wurstclient/hack/BlockMatchHack.java
+++ b/src/main/java/net/wurstclient/hack/BlockMatchHack.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.hack;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.block.Block;
+import net.minecraft.client.gl.VertexBuffer;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.render.*;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.network.Packet;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
+import net.minecraft.network.packet.s2c.play.ChunkDeltaUpdateS2CPacket;
+import net.minecraft.util.Pair;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.Matrix4f;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.EmptyChunk;
+import net.wurstclient.events.CameraTransformViewBobbingListener;
+import net.wurstclient.events.PacketInputListener;
+import net.wurstclient.settings.EnumSetting;
+import net.wurstclient.util.BufferBuilderStorage;
+import net.wurstclient.util.RenderUtils;
+import net.wurstclient.util.RotationUtils;
+import net.wurstclient.util.world.BlockMatchingChunk;
+import net.wurstclient.util.world.BlockMatchingWorld;
+import net.wurstclient.util.world.ArrayBoolChunk;
+import net.wurstclient.util.world.SetBoolChunk;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.opengl.GL11;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.Predicate;
+
+public abstract class BlockMatchHack extends Hack
+    implements PacketInputListener, CameraTransformViewBobbingListener
+{
+    protected final EnumSetting<BlockMatchHack.Area> area = new EnumSetting<>("Area",
+            "The area around the player to search in.\n"
+                    + "Higher values require a faster computer.",
+            BlockMatchHack.Area.values(), BlockMatchHack.Area.D11);
+
+    private int lastDimensionId;
+    private Frustum frustum;
+
+    protected enum DisplayStyle {
+        BLOCKS,
+        TRACERS,
+        BOTH
+    }
+    private DisplayStyle displayStyle;
+    private Predicate<Block> blockMatcher = b -> false;
+    protected BlockMatchingWorld matchingWorld;
+
+    public interface MatchingExecutorService
+    {
+        Future<Void> submitSearch(Runnable r);
+        Future<Void> submitVertexCompile(Runnable r);
+    }
+
+    private class SearchWorkerThreadPoolExecutor extends ThreadPoolExecutor
+        implements MatchingExecutorService
+    {
+        class PriorityFutureTask<T> extends FutureTask<T>
+            implements Comparable<PriorityFutureTask<T>>
+        {
+            private final int priority;
+            public PriorityFutureTask(Runnable task, int priority)
+            {
+                super(task, null);
+                this.priority = priority;
+            }
+
+            @Override
+            public int compareTo(PriorityFutureTask other)
+            {
+                return Integer.compare(this.priority, other.priority);
+            }
+
+            @Override
+            public String toString() {
+                String str = super.toString();
+                return "PriorityFutureTask@" +
+                    Integer.toHexString(this.hashCode()) +
+                    "[Priority " + priority + ", " +
+                    str.substring(str.indexOf('[') + 1);
+            }
+        }
+
+        public SearchWorkerThreadPoolExecutor()
+        {
+            super(
+                1, Runtime.getRuntime().availableProcessors(),
+                15, TimeUnit.SECONDS,
+                new PriorityBlockingQueue<>(),
+                runnable -> {
+                    final Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+                    thread.setName("Wurst-" + BlockMatchHack.this.getClass().getSimpleName() + "Worker-" + thread.getId());
+                    return thread;
+                }
+            );
+        }
+
+        @Override
+        protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<Void> submitSearch(Runnable r) {
+            RunnableFuture<Void> ftask = new PriorityFutureTask<>(r, 0);
+            this.execute(ftask);
+            return ftask;
+        }
+
+        @Override
+        public Future<Void> submitVertexCompile(Runnable r) {
+            RunnableFuture<Void> ftask = new PriorityFutureTask<>(r, 1);
+            this.execute(ftask);
+            return ftask;
+        }
+    }
+    protected SearchWorkerThreadPoolExecutor workerPool;
+    protected @Nullable Queue<Pair<VertexBuffer, BufferBuilder>> bufferUploadQueue;
+
+    protected BlockMatchHack(String name)
+    {
+        super(name);
+        WorldRenderEvents.BEFORE_DEBUG_RENDER.register(e -> frustum = e.frustum());
+        addSetting(area);
+        setDisplayStyle(DisplayStyle.BLOCKS);
+    }
+
+    protected void setDisplayStyle(DisplayStyle style)
+    {
+        displayStyle = style;
+        matchingWorld = style == DisplayStyle.BLOCKS ? new BlockMatchingWorld(ArrayBoolChunk::new) : new BlockMatchingWorld(SetBoolChunk::new);
+        bufferUploadQueue = style == DisplayStyle.TRACERS ? null : new LinkedList<>();
+    }
+
+    @Override
+    public void onEnable()
+    {
+        workerPool = new SearchWorkerThreadPoolExecutor();
+
+        EVENTS.add(PacketInputListener.class, this);
+        EVENTS.add(CameraTransformViewBobbingListener.class, this);
+    }
+
+    public void onDisable()
+    {
+        EVENTS.remove(CameraTransformViewBobbingListener.class, this);
+        EVENTS.remove(PacketInputListener.class, this);
+
+        matchingWorld.clear();
+        workerPool.shutdownNow();
+    }
+
+    @Override
+    public void onReceivedPacket(PacketInputEvent event)
+    {
+        ClientPlayerEntity player = MC.player;
+        ClientWorld world = MC.world;
+        if(player == null || world == null)
+            return;
+
+        Packet<?> packet = event.getPacket();
+        Chunk chunk;
+
+        if(packet instanceof BlockUpdateS2CPacket)
+        {
+            BlockUpdateS2CPacket change = (BlockUpdateS2CPacket)packet;
+            BlockPos pos = change.getPos();
+            chunk = world.getChunk(pos);
+
+        }else if(packet instanceof ChunkDeltaUpdateS2CPacket)
+        {
+            ChunkDeltaUpdateS2CPacket change =
+                    (ChunkDeltaUpdateS2CPacket)packet;
+
+            ArrayList<BlockPos> changedBlocks = new ArrayList<>();
+            change.visitUpdates((pos, state) -> changedBlocks.add(pos));
+            if(changedBlocks.isEmpty())
+                return;
+
+            chunk = world.getChunk(changedBlocks.get(0));
+
+        }else if(packet instanceof ChunkDataS2CPacket)
+        {
+            ChunkDataS2CPacket chunkData = (ChunkDataS2CPacket)packet;
+            chunk = world.getChunk(chunkData.getX(), chunkData.getZ());
+
+        }else
+            return;
+
+        BlockMatchingChunk matchingChunk = matchingWorld.getChunk(chunk.getPos().toLong());
+        if(matchingChunk != null)
+            matchingChunk.queueUpdate(workerPool, bufferUploadQueue);
+    }
+
+    @Override
+    public void onCameraTransformViewBobbing(
+            CameraTransformViewBobbingEvent event)
+    {
+        if(displayStyle != DisplayStyle.BLOCKS)
+            event.cancel();
+    }
+
+    private void addSearchersInRange(ChunkPos center)
+    {
+        int chunkRange = area.getSelected().getChunkRange();
+        for(int x = center.x - chunkRange; x <= center.x + chunkRange; x++)
+            for(int z = center.z - chunkRange; z <= center.z + chunkRange; z++)
+            {
+                Chunk chunk = MC.world.getChunk(x, z);
+                if(chunk instanceof EmptyChunk || matchingWorld.hasChunk(chunk.getPos().toLong()))
+                    continue;
+
+                matchingWorld.addChunk(chunk, blockMatcher).queueUpdate(workerPool, bufferUploadQueue);
+            }
+    }
+
+    private void removeSearchersOutOfRange(ChunkPos center)
+    {
+        int chunkRange = area.getSelected().getChunkRange();
+        matchingWorld.chunkEntries().removeIf(matchingChunk -> {
+            int cx = ChunkPos.getPackedX(matchingChunk.getKey());
+            int cz = ChunkPos.getPackedZ(matchingChunk.getKey());
+            if(Math.abs(cx - center.x) > chunkRange
+                || Math.abs(cz - center.z) > chunkRange)
+            {
+                matchingChunk.getValue().close();
+                return true;
+            }
+            return false;
+        });
+    }
+
+    protected void reset()
+    {
+        matchingWorld.clear();
+    }
+
+    protected void updateSearch()
+    {
+        int dimensionId = MC.world.getRegistryKey().toString().hashCode();
+        if(dimensionId != lastDimensionId)
+        {
+            lastDimensionId = dimensionId;
+            reset();
+        }
+
+        BlockPos eyesPos = new BlockPos(RotationUtils.getEyesPos());
+        ChunkPos center = new ChunkPos(eyesPos);
+
+        removeSearchersOutOfRange(center);
+        addSearchersInRange(center);
+
+        uploadBuffers();
+    }
+
+    private void uploadBuffers()
+    {
+        if(!RenderSystem.isOnRenderThread())
+            throw new UnsupportedOperationException(
+                "Can't upload buffers on non-main thread");
+        if(bufferUploadQueue == null || bufferUploadQueue.isEmpty())
+            return;
+        while(true)
+        {
+            Pair<VertexBuffer, BufferBuilder> buf = bufferUploadQueue.poll();
+            if(buf == null)
+                break;
+            // VertexBuffer::upload is synchronous here since we are guaranteed
+            // to be executing on the main thread.
+            buf.getLeft().upload(buf.getRight());
+            BufferBuilderStorage.putBack(buf.getRight());
+        }
+    }
+
+    protected void setBlockMatcher(Predicate<Block> matcher)
+    {
+        this.blockMatcher = matcher;
+        reset();
+    }
+
+    protected void render(MatrixStack matrixStack, float red, float green, float blue, float alpha)
+    {
+        // GL settings
+        RenderSystem.enableBlend();
+        RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        RenderSystem.disableTexture();
+        RenderSystem.enableCull();
+        RenderSystem.disableDepthTest();
+
+        RenderSystem.setShader(GameRenderer::getPositionShader);
+        RenderSystem.setShaderColor(red, green, blue, alpha);
+
+        final Vec3d cam = RenderUtils.getCameraPos();
+
+        if(displayStyle == DisplayStyle.BLOCKS || displayStyle == DisplayStyle.BOTH)
+        {
+            for(Map.Entry<Long, BlockMatchingChunk> entry : matchingWorld.chunkEntries())
+            {
+                if(entry.getValue().getMatchChunk().isEmpty() || !frustum.isVisible(entry.getValue().getBoundingBox()))
+                    continue;
+                entry.getValue().getVertexBuffer().bind();
+                int cx = ChunkPos.getPackedX(entry.getKey());
+                int cz = ChunkPos.getPackedZ(entry.getKey());
+                matrixStack.push();
+                matrixStack.translate((cx << 4) - cam.x, -cam.y, (cz << 4) - cam.z);
+                entry.getValue().getVertexBuffer().setShader(
+                        matrixStack.peek().getModel(),
+                        RenderSystem.getProjectionMatrix(),
+                        RenderSystem.getShader());
+                matrixStack.pop();
+            }
+        }
+
+        if(displayStyle == DisplayStyle.TRACERS || displayStyle == DisplayStyle.BOTH)
+        {
+            GL11.glEnable(GL11.GL_LINE_SMOOTH);
+            matrixStack.push();
+            BufferBuilder builder = Tessellator.getInstance().getBuffer();
+            builder.begin(VertexFormat.DrawMode.DEBUG_LINES, VertexFormats.POSITION);
+
+            final Matrix4f matrix = matrixStack.peek().getModel();
+            final Vec3d start = RotationUtils.getClientLookVec();
+            for(BlockMatchingChunk chunk : matchingWorld.chunks())
+            {
+                if(!(chunk.getMatchChunk() instanceof SetBoolChunk))
+                    throw new UnsupportedOperationException();
+                for(Long pos : ((SetBoolChunk)chunk.getMatchChunk()).getBlockPositions())
+                {
+                    double x = BlockPos.unpackLongX(pos) - cam.x + 0.5;
+                    double y = BlockPos.unpackLongY(pos) - cam.y + 0.5;
+                    double z = BlockPos.unpackLongZ(pos) - cam.z + 0.5;
+                    builder.vertex(matrix, (float)start.x, (float)start.y, (float)start.z).next();
+                    builder.vertex(matrix, (float)x, (float)y, (float)z).next();
+                }
+            }
+
+            builder.end();
+            BufferRenderer.draw(builder);
+            matrixStack.pop();
+            GL11.glDisable(GL11.GL_LINE_SMOOTH);
+        }
+
+        // Resets
+        RenderSystem.enableDepthTest();
+        RenderSystem.enableTexture();
+        RenderSystem.disableBlend();
+    }
+
+    protected enum Area
+    {
+        D3("3x3 chunks", 1),
+        D5("5x5 chunks", 2),
+        D7("7x7 chunks", 3),
+        D9("9x9 chunks", 4),
+        D11("11x11 chunks", 5),
+        D13("13x13 chunks", 6),
+        D15("15x15 chunks", 7),
+        D17("17x17 chunks", 8),
+        D19("19x19 chunks", 9),
+        D21("21x21 chunks", 10),
+        D23("23x23 chunks", 11),
+        D25("25x25 chunks", 12),
+        D27("27x27 chunks", 13),
+        D29("29x29 chunks", 14),
+        D31("31x31 chunks", 15),
+        D33("33x33 chunks", 16);
+
+        private final String name;
+        private final int chunkRange;
+
+        Area(String name, int chunkRange)
+        {
+            this.name = name;
+            this.chunkRange = chunkRange;
+        }
+
+        public int getChunkRange() {
+            return chunkRange;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+    }
+}

--- a/src/main/java/net/wurstclient/hack/HackList.java
+++ b/src/main/java/net/wurstclient/hack/HackList.java
@@ -135,6 +135,7 @@ public final class HackList implements UpdateListener
 	public final ParkourHack parkourHack = new ParkourHack();
 	public final PlayerEspHack playerEspHack = new PlayerEspHack();
 	public final PlayerFinderHack playerFinderHack = new PlayerFinderHack();
+	public final PortalFinderHack portalFinderHack = new PortalFinderHack();
 	public final PortalGuiHack portalGuiHack = new PortalGuiHack();
 	public final PotionSaverHack potionSaverHack = new PotionSaverHack();
 	public final ProphuntEspHack prophuntEspHack = new ProphuntEspHack();

--- a/src/main/java/net/wurstclient/hacks/PortalFinderHack.java
+++ b/src/main/java/net/wurstclient/hacks/PortalFinderHack.java
@@ -9,38 +9,24 @@ package net.wurstclient.hacks;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.MathHelper;
 import net.wurstclient.Category;
 import net.wurstclient.SearchTags;
 import net.wurstclient.events.RenderListener;
 import net.wurstclient.events.UpdateListener;
 import net.wurstclient.hack.BlockMatchHack;
-import net.wurstclient.settings.ColorSetting;
-import net.wurstclient.settings.SliderSetting;
 import net.wurstclient.util.BlockUtils;
 
-import java.awt.*;
-
-@SearchTags({"cave finder"})
-public final class CaveFinderHack extends BlockMatchHack
+@SearchTags({"portal finder"})
+public final class PortalFinderHack extends BlockMatchHack
 	implements UpdateListener, RenderListener
 {
-	private final ColorSetting color = new ColorSetting("Color",
-		"Caves will be highlighted\n" + "in this color.", Color.RED);
-	
-	private final SliderSetting opacity = new SliderSetting("Opacity",
-		"How opaque the highlights should be.\n" + "0 = breathing animation", 0,
-		0, 1, 0.01,
-		v -> v == 0 ? "Breathing" : SliderSetting.ValueDisplay.PERCENTAGE.getValueString(v));
-
-	public CaveFinderHack()
+	public PortalFinderHack()
 	{
-		super("CaveFinder");
+		super("PortalFinder");
 		setCategory(Category.RENDER);
-		addSetting(color);
-		addSetting(opacity);
-		Block caveAir = BlockUtils.getBlockFromName("minecraft:cave_air");
-		setBlockMatcher(b -> b == caveAir);
+		Block portal = BlockUtils.getBlockFromName("minecraft:nether_portal");
+		setBlockMatcher(b -> b == portal);
+		setDisplayStyle(DisplayStyle.BOTH);
 	}
 
 	@Override
@@ -70,16 +56,6 @@ public final class CaveFinderHack extends BlockMatchHack
 	@Override
 	public void onRender(MatrixStack matrixStack, float partialTicks)
 	{
-		float alpha;
-
-		if (opacity.getValue() > 0)
-			alpha = opacity.getValueF();
-		else {
-			float x = System.currentTimeMillis() % 2000 / 1000F;
-			alpha = 0.25F + 0.25F * MathHelper.sin(x * (float)Math.PI);
-		}
-
-		float[] colorF = color.getColorF();
-		render(matrixStack, colorF[0], colorF[1], colorF[2], alpha);
+		render(matrixStack, 0.9F, 0.15F, 1.F, 0.5F);
 	}
 }

--- a/src/main/java/net/wurstclient/hacks/SearchHack.java
+++ b/src/main/java/net/wurstclient/hacks/SearchHack.java
@@ -7,99 +7,25 @@
  */
 package net.wurstclient.hacks;
 
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ForkJoinTask;
-import java.util.stream.Collectors;
-
-import org.lwjgl.opengl.GL11;
-
-import com.mojang.blaze3d.systems.RenderSystem;
-
-import net.minecraft.block.Block;
-import net.minecraft.client.gl.VertexBuffer;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.Shader;
-import net.minecraft.client.render.Tessellator;
-import net.minecraft.client.render.VertexFormat;
-import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.network.Packet;
-import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
-import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
-import net.minecraft.network.packet.s2c.play.ChunkDeltaUpdateS2CPacket;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Matrix4f;
-import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.chunk.EmptyChunk;
 import net.wurstclient.Category;
 import net.wurstclient.events.PacketInputListener;
 import net.wurstclient.events.RenderListener;
 import net.wurstclient.events.UpdateListener;
-import net.wurstclient.hack.Hack;
+import net.wurstclient.hack.BlockMatchHack;
 import net.wurstclient.settings.BlockSetting;
-import net.wurstclient.settings.EnumSetting;
-import net.wurstclient.settings.SliderSetting;
-import net.wurstclient.util.BlockVertexCompiler;
-import net.wurstclient.util.ChatUtils;
-import net.wurstclient.util.ChunkSearcher;
-import net.wurstclient.util.MinPriorityThreadFactory;
-import net.wurstclient.util.RenderUtils;
-import net.wurstclient.util.RotationUtils;
 
-public final class SearchHack extends Hack
+public final class SearchHack extends BlockMatchHack
 	implements UpdateListener, PacketInputListener, RenderListener
 {
 	private final BlockSetting block = new BlockSetting("Block",
-		"The type of block to search for.", "minecraft:diamond_ore", false);
-	
-	private final EnumSetting<Area> area = new EnumSetting<>("Area",
-		"The area around the player to search in.\n"
-			+ "Higher values require a faster computer.",
-		Area.values(), Area.D11);
-	
-	private final SliderSetting limit = new SliderSetting("Limit",
-		"The maximum number of blocks to display.\n"
-			+ "Higher values require a faster computer.",
-		4, 3, 6, 1,
-		v -> new DecimalFormat("##,###,###").format(Math.pow(10, v)));
-	private int prevLimit;
-	private boolean notify;
-	
-	private final HashMap<Chunk, ChunkSearcher> searchers = new HashMap<>();
-	private final Set<Chunk> chunksToUpdate =
-		Collections.synchronizedSet(new HashSet<>());
-	private ExecutorService pool1;
-	
-	private ForkJoinPool pool2;
-	private ForkJoinTask<HashSet<BlockPos>> getMatchingBlocksTask;
-	private ForkJoinTask<ArrayList<int[]>> compileVerticesTask;
-	
-	private VertexBuffer vertexBuffer;
-	private boolean bufferUpToDate;
+		"The type of block to search for.", "minecraft:diamond_ore", this::reset, false);
 	
 	public SearchHack()
 	{
 		super("Search");
 		setCategory(Category.RENDER);
 		addSetting(block);
-		addSetting(area);
-		addSetting(limit);
 	}
 	
 	@Override
@@ -112,16 +38,10 @@ public final class SearchHack extends Hack
 	@Override
 	public void onEnable()
 	{
-		prevLimit = limit.getValueI();
-		notify = true;
-		
-		pool1 = MinPriorityThreadFactory.newFixedThreadPool();
-		pool2 = new ForkJoinPool();
-		
-		bufferUpToDate = false;
-		
+		super.onEnable();
+
+		setBlockMatcher(b -> b == block.getBlock());
 		EVENTS.add(UpdateListener.class, this);
-		EVENTS.add(PacketInputListener.class, this);
 		EVENTS.add(RenderListener.class, this);
 	}
 	
@@ -129,393 +49,21 @@ public final class SearchHack extends Hack
 	public void onDisable()
 	{
 		EVENTS.remove(UpdateListener.class, this);
-		EVENTS.remove(PacketInputListener.class, this);
 		EVENTS.remove(RenderListener.class, this);
-		
-		stopPool2Tasks();
-		pool1.shutdownNow();
-		pool2.shutdownNow();
-		
-		if(vertexBuffer != null)
-			vertexBuffer.close();
-		
-		chunksToUpdate.clear();
-	}
-	
-	@Override
-	public void onReceivedPacket(PacketInputEvent event)
-	{
-		ClientPlayerEntity player = MC.player;
-		ClientWorld world = MC.world;
-		if(player == null || world == null)
-			return;
-		
-		Packet<?> packet = event.getPacket();
-		Chunk chunk;
-		
-		if(packet instanceof BlockUpdateS2CPacket change)
-		{
-			BlockPos pos = change.getPos();
-			chunk = world.getChunk(pos);
-			
-		}else if(packet instanceof ChunkDeltaUpdateS2CPacket change)
-		{
-			ArrayList<BlockPos> changedBlocks = new ArrayList<>();
-			change.visitUpdates((pos, state) -> changedBlocks.add(pos));
-			if(changedBlocks.isEmpty())
-				return;
-			
-			chunk = world.getChunk(changedBlocks.get(0));
-			
-		}else if(packet instanceof ChunkDataS2CPacket chunkData)
-			chunk = world.getChunk(chunkData.getX(), chunkData.getZ());
-		else
-			return;
-		
-		chunksToUpdate.add(chunk);
+
+		super.onDisable();
 	}
 	
 	@Override
 	public void onUpdate()
 	{
-		Block currentBlock = block.getBlock();
-		BlockPos eyesPos = new BlockPos(RotationUtils.getEyesPos());
-		
-		ChunkPos center = getPlayerChunkPos(eyesPos);
-		int range = area.getSelected().chunkRange;
-		int dimensionId = MC.world.getRegistryKey().toString().hashCode();
-		
-		addSearchersInRange(center, range, currentBlock, dimensionId);
-		removeSearchersOutOfRange(center, range);
-		replaceSearchersWithDifferences(currentBlock, dimensionId);
-		replaceSearchersWithChunkUpdate(currentBlock, dimensionId);
-		
-		if(!areAllChunkSearchersDone())
-			return;
-		
-		checkIfLimitChanged();
-		
-		if(getMatchingBlocksTask == null)
-			startGetMatchingBlocksTask(eyesPos);
-		
-		if(!getMatchingBlocksTask.isDone())
-			return;
-		
-		if(compileVerticesTask == null)
-			startCompileVerticesTask();
-		
-		if(!compileVerticesTask.isDone())
-			return;
-		
-		if(!bufferUpToDate)
-			setBufferFromTask();
+		updateSearch();
 	}
-	
+
 	@Override
 	public void onRender(MatrixStack matrixStack, float partialTicks)
 	{
-		// GL settings
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-		GL11.glEnable(GL11.GL_LINE_SMOOTH);
-		GL11.glEnable(GL11.GL_CULL_FACE);
-		GL11.glDisable(GL11.GL_DEPTH_TEST);
-		
-		matrixStack.push();
-		RenderUtils.applyRegionalRenderOffset(matrixStack);
-		
-		// generate rainbow color
-		float x = System.currentTimeMillis() % 2000 / 1000F;
-		float red = 0.5F + 0.5F * MathHelper.sin(x * (float)Math.PI);
-		float green =
-			0.5F + 0.5F * MathHelper.sin((x + 4F / 3F) * (float)Math.PI);
-		float blue =
-			0.5F + 0.5F * MathHelper.sin((x + 8F / 3F) * (float)Math.PI);
-		
-		RenderSystem.setShaderColor(red, green, blue, 0.5F);
-		RenderSystem.setShader(GameRenderer::getPositionShader);
-		
-		if(vertexBuffer != null)
-		{
-			Matrix4f viewMatrix = matrixStack.peek().getModel();
-			Matrix4f projMatrix = RenderSystem.getProjectionMatrix();
-			Shader shader = RenderSystem.getShader();
-			vertexBuffer.setShader(viewMatrix, projMatrix, shader);
-		}
-		
-		matrixStack.pop();
-		
-		// GL resets
-		RenderSystem.setShaderColor(1, 1, 1, 1);
-		GL11.glEnable(GL11.GL_DEPTH_TEST);
-		GL11.glDisable(GL11.GL_BLEND);
-		GL11.glDisable(GL11.GL_LINE_SMOOTH);
-	}
-	
-	private ChunkPos getPlayerChunkPos(BlockPos eyesPos)
-	{
-		int chunkX = eyesPos.getX() >> 4;
-		int chunkZ = eyesPos.getZ() >> 4;
-		return MC.world.getChunk(chunkX, chunkZ).getPos();
-	}
-	
-	private void addSearchersInRange(ChunkPos center, int chunkRange,
-		Block block, int dimensionId)
-	{
-		ArrayList<Chunk> chunksInRange = getChunksInRange(center, chunkRange);
-		
-		for(Chunk chunk : chunksInRange)
-		{
-			if(searchers.containsKey(chunk))
-				continue;
-			
-			addSearcher(chunk, block, dimensionId);
-		}
-	}
-	
-	private ArrayList<Chunk> getChunksInRange(ChunkPos center, int chunkRange)
-	{
-		ArrayList<Chunk> chunksInRange = new ArrayList<>();
-		
-		for(int x = center.x - chunkRange; x <= center.x + chunkRange; x++)
-			for(int z = center.z - chunkRange; z <= center.z + chunkRange; z++)
-			{
-				Chunk chunk = MC.world.getChunk(x, z);
-				if(chunk instanceof EmptyChunk)
-					continue;
-				
-				chunksInRange.add(chunk);
-			}
-		
-		return chunksInRange;
-	}
-	
-	private void removeSearchersOutOfRange(ChunkPos center, int chunkRange)
-	{
-		for(ChunkSearcher searcher : new ArrayList<>(searchers.values()))
-		{
-			ChunkPos searcherPos = searcher.getChunk().getPos();
-			
-			if(Math.abs(searcherPos.x - center.x) <= chunkRange
-				&& Math.abs(searcherPos.z - center.z) <= chunkRange)
-				continue;
-			
-			removeSearcher(searcher);
-		}
-	}
-	
-	private void replaceSearchersWithDifferences(Block currentBlock,
-		int dimensionId)
-	{
-		for(ChunkSearcher oldSearcher : new ArrayList<>(searchers.values()))
-		{
-			if(currentBlock.equals(oldSearcher.getBlock())
-				&& dimensionId == oldSearcher.getDimensionId())
-				continue;
-			
-			removeSearcher(oldSearcher);
-			addSearcher(oldSearcher.getChunk(), currentBlock, dimensionId);
-		}
-	}
-	
-	private void replaceSearchersWithChunkUpdate(Block currentBlock,
-		int dimensionId)
-	{
-		synchronized(chunksToUpdate)
-		{
-			if(chunksToUpdate.isEmpty())
-				return;
-			
-			for(Iterator<Chunk> itr = chunksToUpdate.iterator(); itr.hasNext();)
-			{
-				Chunk chunk = itr.next();
-				
-				ChunkSearcher oldSearcher = searchers.get(chunk);
-				if(oldSearcher == null)
-					continue;
-				
-				removeSearcher(oldSearcher);
-				addSearcher(chunk, currentBlock, dimensionId);
-				itr.remove();
-			}
-		}
-	}
-	
-	private void addSearcher(Chunk chunk, Block block, int dimensionId)
-	{
-		stopPool2Tasks();
-		
-		ChunkSearcher searcher = new ChunkSearcher(chunk, block, dimensionId);
-		searchers.put(chunk, searcher);
-		searcher.startSearching(pool1);
-	}
-	
-	private void removeSearcher(ChunkSearcher searcher)
-	{
-		stopPool2Tasks();
-		
-		searchers.remove(searcher.getChunk());
-		searcher.cancelSearching();
-	}
-	
-	private void stopPool2Tasks()
-	{
-		if(getMatchingBlocksTask != null)
-		{
-			getMatchingBlocksTask.cancel(true);
-			getMatchingBlocksTask = null;
-		}
-		
-		if(compileVerticesTask != null)
-		{
-			compileVerticesTask.cancel(true);
-			compileVerticesTask = null;
-		}
-		
-		bufferUpToDate = false;
-	}
-	
-	private boolean areAllChunkSearchersDone()
-	{
-		for(ChunkSearcher searcher : searchers.values())
-			if(searcher.getStatus() != ChunkSearcher.Status.DONE)
-				return false;
-			
-		return true;
-	}
-	
-	private void checkIfLimitChanged()
-	{
-		if(limit.getValueI() != prevLimit)
-		{
-			stopPool2Tasks();
-			notify = true;
-			prevLimit = limit.getValueI();
-		}
-	}
-	
-	private void startGetMatchingBlocksTask(BlockPos eyesPos)
-	{
-		int maxBlocks = (int)Math.pow(10, limit.getValueI());
-		
-		Callable<HashSet<BlockPos>> task = () -> searchers.values()
-			.parallelStream()
-			.flatMap(searcher -> searcher.getMatchingBlocks().stream())
-			.sorted(Comparator
-				.comparingInt(pos -> eyesPos.getManhattanDistance(pos)))
-			.limit(maxBlocks).collect(Collectors.toCollection(HashSet::new));
-		
-		getMatchingBlocksTask = pool2.submit(task);
-	}
-	
-	private HashSet<BlockPos> getMatchingBlocksFromTask()
-	{
-		HashSet<BlockPos> matchingBlocks = new HashSet<>();
-		
-		try
-		{
-			matchingBlocks = getMatchingBlocksTask.get();
-			
-		}catch(InterruptedException | ExecutionException e)
-		{
-			throw new RuntimeException(e);
-		}
-		
-		int maxBlocks = (int)Math.pow(10, limit.getValueI());
-		
-		if(matchingBlocks.size() < maxBlocks)
-			notify = true;
-		else if(notify)
-		{
-			ChatUtils.warning("Search found \u00a7lA LOT\u00a7r of blocks!"
-				+ " To prevent lag, it will only show the closest \u00a76"
-				+ limit.getValueString() + "\u00a7r results.");
-			notify = false;
-		}
-		
-		return matchingBlocks;
-	}
-	
-	private void startCompileVerticesTask()
-	{
-		HashSet<BlockPos> matchingBlocks = getMatchingBlocksFromTask();
-		
-		BlockPos camPos = RenderUtils.getCameraBlockPos();
-		int regionX = (camPos.getX() >> 9) * 512;
-		int regionZ = (camPos.getZ() >> 9) * 512;
-		
-		Callable<ArrayList<int[]>> task =
-			BlockVertexCompiler.createTask(matchingBlocks, regionX, regionZ);
-		
-		compileVerticesTask = pool2.submit(task);
-	}
-	
-	private void setBufferFromTask()
-	{
-		ArrayList<int[]> vertices = getVerticesFromTask();
-		
-		if(vertexBuffer != null)
-			vertexBuffer.close();
-		
-		vertexBuffer = new VertexBuffer();
-		
-		BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
-		bufferBuilder.begin(VertexFormat.DrawMode.QUADS,
-			VertexFormats.POSITION);
-		
-		for(int[] vertex : vertices)
-			bufferBuilder.vertex(vertex[0], vertex[1], vertex[2]).next();
-		
-		bufferBuilder.end();
-		vertexBuffer.upload(bufferBuilder);
-		
-		bufferUpToDate = true;
-	}
-	
-	public ArrayList<int[]> getVerticesFromTask()
-	{
-		try
-		{
-			return compileVerticesTask.get();
-			
-		}catch(InterruptedException | ExecutionException e)
-		{
-			throw new RuntimeException(e);
-		}
-	}
-	
-	private enum Area
-	{
-		D3("3x3 chunks", 1),
-		D5("5x5 chunks", 2),
-		D7("7x7 chunks", 3),
-		D9("9x9 chunks", 4),
-		D11("11x11 chunks", 5),
-		D13("13x13 chunks", 6),
-		D15("15x15 chunks", 7),
-		D17("17x17 chunks", 8),
-		D19("19x19 chunks", 9),
-		D21("21x21 chunks", 10),
-		D23("23x23 chunks", 11),
-		D25("25x25 chunks", 12),
-		D27("27x27 chunks", 13),
-		D29("29x29 chunks", 14),
-		D31("31x31 chunks", 15),
-		D33("33x33 chunks", 16);
-		
-		private final String name;
-		private final int chunkRange;
-		
-		private Area(String name, int chunkRange)
-		{
-			this.name = name;
-			this.chunkRange = chunkRange;
-		}
-		
-		@Override
-		public String toString()
-		{
-			return name;
-		}
+		float[] rainbow = WURST.getGui().getRainbowColor();
+		render(matrixStack, rainbow[0], rainbow[1], rainbow[2], 0.5F);
 	}
 }

--- a/src/main/java/net/wurstclient/settings/BlockListSetting.java
+++ b/src/main/java/net/wurstclient/settings/BlockListSetting.java
@@ -29,21 +29,28 @@ import net.wurstclient.util.BlockUtils;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
 import net.wurstclient.util.json.WsonArray;
+import org.jetbrains.annotations.Nullable;
 
 public final class BlockListSetting extends Setting
 {
 	private final ArrayList<String> blockNames = new ArrayList<>();
 	private final String[] defaultNames;
 	
-	public BlockListSetting(String name, String description, String... blocks)
+	public BlockListSetting(String name, String description,
+		@Nullable Runnable changeCallback, String... blocks)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		
 		Arrays.stream(blocks).parallel()
 			.map(s -> Registry.BLOCK.get(new Identifier(s)))
 			.filter(Objects::nonNull).map(BlockUtils::getName).distinct()
 			.sorted().forEachOrdered(s -> blockNames.add(s));
 		defaultNames = blockNames.toArray(new String[0]);
+	}
+
+	public BlockListSetting(String name, String description, String... blocks)
+	{
+		this(name, description, null, blocks);
 	}
 	
 	public List<String> getBlockNames()
@@ -60,6 +67,8 @@ public final class BlockListSetting extends Setting
 		blockNames.add(name);
 		Collections.sort(blockNames);
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public void remove(int index)
@@ -69,6 +78,8 @@ public final class BlockListSetting extends Setting
 		
 		blockNames.remove(index);
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public void resetToDefaults()
@@ -76,6 +87,8 @@ public final class BlockListSetting extends Setting
 		blockNames.clear();
 		blockNames.addAll(Arrays.asList(defaultNames));
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	@Override
@@ -96,7 +109,8 @@ public final class BlockListSetting extends Setting
 				.map(s -> Registry.BLOCK.get(new Identifier(s)))
 				.filter(Objects::nonNull).map(BlockUtils::getName).distinct()
 				.sorted().forEachOrdered(s -> blockNames.add(s));
-			
+
+			notifyChange();
 		}catch(JsonException e)
 		{
 			e.printStackTrace();

--- a/src/main/java/net/wurstclient/settings/BlockSetting.java
+++ b/src/main/java/net/wurstclient/settings/BlockSetting.java
@@ -23,17 +23,18 @@ import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.BlockUtils;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
+import org.jetbrains.annotations.Nullable;
 
 public final class BlockSetting extends Setting
 {
-	private String blockName = "";
+	private String blockName;
 	private final String defaultName;
 	private final boolean allowAir;
 	
 	public BlockSetting(String name, String description, String blockName,
-		boolean allowAir)
+		@Nullable Runnable changeCallback, boolean allowAir)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		
 		Block block = BlockUtils.getBlockFromName(blockName);
 		Objects.requireNonNull(block);
@@ -42,10 +43,11 @@ public final class BlockSetting extends Setting
 		defaultName = this.blockName;
 		this.allowAir = allowAir;
 	}
-	
-	public BlockSetting(String name, String blockName, boolean allowAir)
+
+	public BlockSetting(String name, String description, String blockName,
+		boolean allowAir)
 	{
-		this(name, "", blockName, allowAir);
+		this(name, description, blockName, null, allowAir);
 	}
 	
 	public Block getBlock()
@@ -73,6 +75,8 @@ public final class BlockSetting extends Setting
 		
 		blockName = newName;
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public void setBlockName(String blockName)
@@ -87,6 +91,8 @@ public final class BlockSetting extends Setting
 	{
 		blockName = defaultName;
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	@Override
@@ -110,7 +116,8 @@ public final class BlockSetting extends Setting
 				throw new JsonException();
 			
 			blockName = BlockUtils.getName(newBlock);
-			
+
+			notifyChange();
 		}catch(JsonException e)
 		{
 			e.printStackTrace();

--- a/src/main/java/net/wurstclient/settings/CheckboxSetting.java
+++ b/src/main/java/net/wurstclient/settings/CheckboxSetting.java
@@ -18,6 +18,7 @@ import net.wurstclient.clickgui.Component;
 import net.wurstclient.clickgui.components.CheckboxComponent;
 import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.json.JsonUtils;
+import org.jetbrains.annotations.Nullable;
 
 public class CheckboxSetting extends Setting implements CheckboxLock
 {
@@ -25,11 +26,17 @@ public class CheckboxSetting extends Setting implements CheckboxLock
 	private final boolean checkedByDefault;
 	private CheckboxLock lock;
 	
-	public CheckboxSetting(String name, String description, boolean checked)
+	public CheckboxSetting(String name, String description,
+		@Nullable Runnable changeCallback, boolean checked)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		this.checked = checked;
 		checkedByDefault = checked;
+	}
+
+	public CheckboxSetting(String name, String description, boolean checked)
+	{
+		this(name, description, null, checked);
 	}
 	
 	public CheckboxSetting(String name, boolean checked)
@@ -62,6 +69,8 @@ public class CheckboxSetting extends Setting implements CheckboxLock
 		update();
 		
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public final boolean isLocked()

--- a/src/main/java/net/wurstclient/settings/ColorSetting.java
+++ b/src/main/java/net/wurstclient/settings/ColorSetting.java
@@ -22,17 +22,24 @@ import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.ColorUtils;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
+import org.jetbrains.annotations.Nullable;
 
 public final class ColorSetting extends Setting
 {
 	private Color color;
 	private final Color defaultColor;
-	
-	public ColorSetting(String name, String description, Color color)
+
+	public ColorSetting(String name, String description,
+		@Nullable Runnable changeCallback, Color color)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		this.color = Objects.requireNonNull(color);
 		defaultColor = color;
+	}
+
+	public ColorSetting(String name, String description, Color color)
+	{
+		this(name, description, null, color);
 	}
 	
 	public ColorSetting(String name, Color color)

--- a/src/main/java/net/wurstclient/settings/EnumSetting.java
+++ b/src/main/java/net/wurstclient/settings/EnumSetting.java
@@ -18,6 +18,7 @@ import net.wurstclient.clickgui.Component;
 import net.wurstclient.clickgui.components.ComboBoxComponent;
 import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.json.JsonUtils;
+import org.jetbrains.annotations.Nullable;
 
 public final class EnumSetting<T extends Enum<T>> extends Setting
 {
@@ -25,12 +26,18 @@ public final class EnumSetting<T extends Enum<T>> extends Setting
 	private T selected;
 	private final T defaultSelected;
 	
-	public EnumSetting(String name, String description, T[] values, T selected)
+	public EnumSetting(String name, String description,
+		@Nullable Runnable changeCallback, T[] values, T selected)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		this.values = Objects.requireNonNull(values);
 		this.selected = Objects.requireNonNull(selected);
 		defaultSelected = selected;
+	}
+
+	public EnumSetting(String name, String description, T[] values, T selected)
+	{
+		this(name, description, null, values, selected);
 	}
 	
 	public EnumSetting(String name, T[] values, T selected)
@@ -57,6 +64,8 @@ public final class EnumSetting<T extends Enum<T>> extends Setting
 	{
 		this.selected = Objects.requireNonNull(selected);
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public boolean setSelected(String selected)

--- a/src/main/java/net/wurstclient/settings/FileSetting.java
+++ b/src/main/java/net/wurstclient/settings/FileSetting.java
@@ -27,6 +27,7 @@ import net.wurstclient.clickgui.components.FileComponent;
 import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
+import org.jetbrains.annotations.Nullable;
 
 public final class FileSetting extends Setting
 {
@@ -34,13 +35,20 @@ public final class FileSetting extends Setting
 	private String selectedFile = "";
 	private final Consumer<Path> createDefaultFiles;
 	
-	public FileSetting(String name, String description, String folderName,
+	public FileSetting(String name, String description,
+		@Nullable Runnable changeCallback, String folderName,
 		Consumer<Path> createDefaultFiles)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		folder = WurstClient.INSTANCE.getWurstFolder().resolve(folderName);
 		this.createDefaultFiles = createDefaultFiles;
 		setSelectedFileToDefault();
+	}
+
+	public FileSetting(String name, String description, String folderName,
+		Consumer<Path> createDefaultFiles)
+	{
+		this(name, description, null, folderName, createDefaultFiles);
 	}
 	
 	public Path getFolder()
@@ -68,6 +76,8 @@ public final class FileSetting extends Setting
 		
 		this.selectedFile = selectedFile;
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	private void setSelectedFileToDefault()
@@ -115,6 +125,8 @@ public final class FileSetting extends Setting
 		
 		setSelectedFileToDefault();
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public ArrayList<Path> listFiles()
@@ -150,7 +162,8 @@ public final class FileSetting extends Setting
 				throw new JsonException();
 			
 			selectedFile = newFile;
-			
+
+			notifyChange();
 		}catch(JsonException e)
 		{
 			e.printStackTrace();

--- a/src/main/java/net/wurstclient/settings/ItemListSetting.java
+++ b/src/main/java/net/wurstclient/settings/ItemListSetting.java
@@ -28,15 +28,17 @@ import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.json.JsonException;
 import net.wurstclient.util.json.JsonUtils;
 import net.wurstclient.util.json.WsonArray;
+import org.jetbrains.annotations.Nullable;
 
 public final class ItemListSetting extends Setting
 {
 	private final ArrayList<String> itemNames = new ArrayList<>();
 	private final String[] defaultNames;
 	
-	public ItemListSetting(String name, String description, String... items)
+	public ItemListSetting(String name, String description,
+		@Nullable Runnable changeCallback, String... items)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		
 		Arrays.stream(items).parallel()
 			.map(s -> Registry.ITEM.get(new Identifier(s)))
@@ -44,6 +46,11 @@ public final class ItemListSetting extends Setting
 			.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted()
 			.forEachOrdered(s -> itemNames.add(s));
 		defaultNames = itemNames.toArray(new String[0]);
+	}
+
+	public ItemListSetting(String name, String description, String... items)
+	{
+		this(name, description, null, items);
 	}
 	
 	public List<String> getItemNames()
@@ -60,6 +67,8 @@ public final class ItemListSetting extends Setting
 		itemNames.add(name);
 		Collections.sort(itemNames);
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public void remove(int index)
@@ -69,6 +78,8 @@ public final class ItemListSetting extends Setting
 		
 		itemNames.remove(index);
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public void resetToDefaults()
@@ -76,6 +87,8 @@ public final class ItemListSetting extends Setting
 		itemNames.clear();
 		itemNames.addAll(Arrays.asList(defaultNames));
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	@Override
@@ -97,7 +110,8 @@ public final class ItemListSetting extends Setting
 				.filter(Objects::nonNull)
 				.map(i -> Registry.ITEM.getId(i).toString()).distinct().sorted()
 				.forEachOrdered(s -> itemNames.add(s));
-			
+
+			notifyChange();
 		}catch(JsonException e)
 		{
 			e.printStackTrace();

--- a/src/main/java/net/wurstclient/settings/Setting.java
+++ b/src/main/java/net/wurstclient/settings/Setting.java
@@ -19,16 +19,26 @@ import net.minecraft.text.Style;
 import net.wurstclient.WurstClient;
 import net.wurstclient.clickgui.Component;
 import net.wurstclient.keybinds.PossibleKeybind;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class Setting
 {
 	private final String name;
 	private final String description;
+	private final @Nullable Runnable changeCallback;
 	
-	public Setting(String name, String description)
+	protected Setting(String name, String description,
+		@Nullable Runnable changeCallback)
 	{
 		this.name = Objects.requireNonNull(name);
 		this.description = Objects.requireNonNull(description);
+		this.changeCallback = changeCallback;
+	}
+
+	protected final void notifyChange()
+	{
+		if(changeCallback != null)
+			changeCallback.run();
 	}
 	
 	public final String getName()

--- a/src/main/java/net/wurstclient/settings/SliderSetting.java
+++ b/src/main/java/net/wurstclient/settings/SliderSetting.java
@@ -18,6 +18,7 @@ import net.wurstclient.clickgui.components.SliderComponent;
 import net.wurstclient.keybinds.PossibleKeybind;
 import net.wurstclient.util.MathUtils;
 import net.wurstclient.util.json.JsonUtils;
+import org.jetbrains.annotations.Nullable;
 
 public class SliderSetting extends Setting implements SliderLock
 {
@@ -33,10 +34,11 @@ public class SliderSetting extends Setting implements SliderLock
 	private double usableMin;
 	private double usableMax;
 	
-	public SliderSetting(String name, String description, double value,
-		double minimum, double maximum, double increment, ValueDisplay display)
+	public SliderSetting(String name, String description,
+		 @Nullable Runnable changeCallback, double value,
+		 double minimum, double maximum, double increment, ValueDisplay display)
 	{
-		super(name, description);
+		super(name, description, changeCallback);
 		this.value = value;
 		defaultValue = value;
 		
@@ -48,6 +50,13 @@ public class SliderSetting extends Setting implements SliderLock
 		
 		this.increment = increment;
 		this.display = display;
+	}
+
+	public SliderSetting(String name, String description, double value,
+		double minimum, double maximum, double increment, ValueDisplay display)
+	{
+		this(name, description, null,
+			value, minimum, maximum, increment, display);
 	}
 	
 	public SliderSetting(String name, double value, double minimum,
@@ -100,6 +109,8 @@ public class SliderSetting extends Setting implements SliderLock
 		update();
 		
 		WurstClient.INSTANCE.saveSettings();
+
+		notifyChange();
 	}
 	
 	public final void increaseValue()

--- a/src/main/java/net/wurstclient/util/BufferBuilderStorage.java
+++ b/src/main/java/net/wurstclient/util/BufferBuilderStorage.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util;
+
+import net.minecraft.client.render.BufferBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+public enum BufferBuilderStorage
+{
+    ;
+
+    private static final ConcurrentLinkedDeque<BufferBuilder> STORAGE =
+        new ConcurrentLinkedDeque<>();
+
+    public static @NotNull BufferBuilder take()
+    {
+        BufferBuilder buf = STORAGE.pollFirst();
+        if(buf == null)
+            return new BufferBuilder(256);
+        return buf;
+    }
+
+    public static void putBack(BufferBuilder buf)
+    {
+        STORAGE.addFirst(buf);
+    }
+}

--- a/src/main/java/net/wurstclient/util/RenderUtils.java
+++ b/src/main/java/net/wurstclient/util/RenderUtils.java
@@ -7,6 +7,7 @@
  */
 package net.wurstclient.util;
 
+import net.minecraft.util.math.*;
 import org.lwjgl.opengl.GL11;
 
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -19,20 +20,20 @@ import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
-import net.minecraft.util.math.Matrix4f;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.math.Vec3f;
 import net.minecraft.world.chunk.Chunk;
 import net.wurstclient.WurstClient;
 
 public enum RenderUtils
 {
 	;
-	
+
 	private static final Box DEFAULT_BOX = new Box(0, 0, 0, 1, 1, 1);
-	
+	private static Vector4f screenspaceMiddlePoint = new Vector4f();
+
+	public static Vector4f getScreenspaceMiddlePoint() {
+		return screenspaceMiddlePoint;
+	}
+
 	public static void scissorBox(int startX, int startY, int endX, int endY)
 	{
 		int width = endX - startX;

--- a/src/main/java/net/wurstclient/util/world/ArrayBoolChunk.java
+++ b/src/main/java/net/wurstclient/util/world/ArrayBoolChunk.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util.world;
+
+import org.jetbrains.annotations.Contract;
+
+import java.util.Arrays;
+
+/**
+ * Implementation of a {@link BoolChunk} that stores the matched block
+ * flags into a contiguous array.
+ * This is the most space efficient representation, taking only 1 bit per
+ * block, and is perfect for bulk matching (e.g. base finding),
+ * but it isn't the best for iterating sparse match sets (e.g. finding
+ * diamonds); for that see {@link SetBoolChunk}.
+ */
+public class ArrayBoolChunk implements BoolChunk
+{
+    // NOTE: this implementation is not yet ready for 1.18's below-zero Y coords
+
+    private final short[] values = new short[HEIGHT * LENGTH];
+    private int bitsSetAtLeastOnce;
+
+    public ArrayBoolChunk()
+    {
+        clear();
+    }
+
+    @Contract(mutates = "this")
+    @Override
+    public void clear()
+    {
+        Arrays.fill(values, (short)0);
+        bitsSetAtLeastOnce = 0;
+    }
+
+    @Contract(pure = true)
+    public short getRow(int y, int z)
+    {
+        return values[y + z * HEIGHT];
+    }
+
+    @Contract(pure = true)
+    @Override
+    public boolean get(int x, int y, int z)
+    {
+        return ((values[y + (z & (LENGTH - 1)) * HEIGHT] >> (x & (WIDTH - 1))) & 1) == 1;
+    }
+
+    @Contract(mutates = "this")
+    @Override
+    public void set(int x, int y, int z)
+    {
+        values[y + (z & (LENGTH - 1)) * HEIGHT] |= 1 << (x & (WIDTH - 1));
+        bitsSetAtLeastOnce++;
+    }
+
+    @Contract(mutates = "this")
+    @Override
+    public void unset(int x, int y, int z)
+    {
+        values[y + (z & (LENGTH - 1)) * HEIGHT] &= ~(1 << (x & (WIDTH - 1)));
+    }
+
+    @Contract(pure = true)
+    @Override
+    public int getBitsSetAtLeastOnce()
+    {
+        return bitsSetAtLeastOnce;
+    }
+
+    @Contract(pure = true)
+    @Override
+    public boolean isEmpty()
+    {
+        if(bitsSetAtLeastOnce == 0)
+            return true;
+        int sum = 0;
+        for (short v : values) {
+            sum |= v;
+        }
+        return sum == 0;
+    }
+}

--- a/src/main/java/net/wurstclient/util/world/BlockMatchingChunk.java
+++ b/src/main/java/net/wurstclient/util/world/BlockMatchingChunk.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util.world;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.gl.VertexBuffer;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.util.Pair;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.Chunk;
+import net.wurstclient.hack.BlockMatchHack;
+import net.wurstclient.util.BlockVertexCompiler;
+import net.wurstclient.util.ChunkSearcher;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Queue;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public class BlockMatchingChunk
+{
+    private final BlockMatchingWorld matchingWorld;
+    private final int cx;
+    private final int cz;
+
+    private final ChunkSearcher searcher;
+
+    private final BoolChunk matchChunk;
+
+    private final AtomicBoolean hasSearchTask = new AtomicBoolean(false);
+    private final AtomicBoolean runSearch = new AtomicBoolean(false);
+    private Future<Void> searchTask;
+
+    private final VertexBuffer vertexBuffer = new VertexBuffer();
+
+    private Future<Void> vertexCompileTask;
+
+    private final Box boundingBox;
+
+    BlockMatchingChunk(BlockMatchingWorld matchingWorld, Chunk chunk, Supplier<BoolChunk> matchChunkSupplier, Predicate<Block> blockMatcher)
+    {
+        this.matchingWorld = matchingWorld;
+        this.matchChunk = matchChunkSupplier.get();
+        this.searcher = new ChunkSearcher(chunk, blockMatcher, this.matchChunk);
+        this.cx = chunk.getPos().x;
+        this.cz = chunk.getPos().z;
+        int bx = cx << 4;
+        int bz = cz << 4;
+        this.boundingBox = new Box(bx, 0, bz, bx + 16.0, chunk.getHeight(), bz + 16.0);
+    }
+
+    private void queueVertexUpdate(BlockMatchHack.MatchingExecutorService pool,
+         @NotNull Queue<Pair<VertexBuffer, BufferBuilder>> bufferUploadQueue)
+    {
+        if(vertexCompileTask != null)
+            vertexCompileTask.cancel(false);
+        vertexCompileTask = pool.submitVertexCompile(() ->
+        {
+            bufferUploadQueue.add(new Pair<>(vertexBuffer, BlockVertexCompiler.compileVertices(matchingWorld, cx, cz)));
+            vertexCompileTask = null;
+        });
+    }
+
+    public void queueUpdate(BlockMatchHack.MatchingExecutorService pool, @Nullable Queue<Pair<VertexBuffer, BufferBuilder>> bufferUploadQueue)
+    {
+        runSearch.set(true); // Asks for a search, or re-search if task is already running
+        if(!hasSearchTask.getAndSet(true))
+            searchTask = pool.submitSearch(() ->
+            {
+                while(runSearch.getAndSet(false))
+                {
+                    searcher.search();
+                    if(bufferUploadQueue != null && !runSearch.get() && !matchChunk.isEmpty())
+                    {
+                        queueVertexUpdate(pool, bufferUploadQueue);
+                        // Queue updates for chunks around it as new matching info becomes available,
+                        // potentially changing the face count on chunk egdes.
+                        BlockMatchingChunk neighbor = matchingWorld.getChunk(ChunkPos.toLong(cx - 1, cz));
+                        if(neighbor != null && !neighbor.getMatchChunk().isEmpty())
+                            neighbor.queueVertexUpdate(pool, bufferUploadQueue);
+                        neighbor = matchingWorld.getChunk(ChunkPos.toLong(cx + 1, cz));
+                        if(neighbor != null && !neighbor.getMatchChunk().isEmpty())
+                            neighbor.queueVertexUpdate(pool, bufferUploadQueue);
+                        neighbor = matchingWorld.getChunk(ChunkPos.toLong(cx, cz - 1));
+                        if(neighbor != null && !neighbor.getMatchChunk().isEmpty())
+                            neighbor.queueVertexUpdate(pool, bufferUploadQueue);
+                        neighbor = matchingWorld.getChunk(ChunkPos.toLong(cx, cz + 1));
+                        if(neighbor != null && !neighbor.getMatchChunk().isEmpty())
+                            neighbor.queueVertexUpdate(pool, bufferUploadQueue);
+                    }
+                }
+                hasSearchTask.set(false);
+            });
+    }
+
+    public BoolChunk getMatchChunk()
+    {
+        return matchChunk;
+    }
+
+    public VertexBuffer getVertexBuffer()
+    {
+        return vertexBuffer;
+    }
+
+    public Box getBoundingBox()
+    {
+        return boundingBox;
+    }
+
+    public void close()
+    {
+        searcher.interrupt();
+        searchTask.cancel(false);
+        vertexBuffer.close();
+    }
+}

--- a/src/main/java/net/wurstclient/util/world/BlockMatchingWorld.java
+++ b/src/main/java/net/wurstclient/util/world/BlockMatchingWorld.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util.world;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import net.minecraft.block.Block;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.Chunk;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public class BlockMatchingWorld implements BoolView {
+    private final Supplier<BoolChunk> matchChunkSupplier;
+    private final Map<Long, BlockMatchingChunk> blockMatchingChunks =
+        new Long2ObjectOpenHashMap<>();
+
+    public BlockMatchingWorld(Supplier<BoolChunk> matchChunkSupplier)
+    {
+        this.matchChunkSupplier = matchChunkSupplier;
+    }
+
+    @Contract(pure = true)
+    private static long blockToChunkPos(int x, int z)
+    {
+        return ChunkPos.toLong(x >> 4, z >> 4);
+    }
+
+    public void clear()
+    {
+        for(BlockMatchingChunk matchingChunk : blockMatchingChunks.values())
+            matchingChunk.close();
+        blockMatchingChunks.clear();
+    }
+
+    @Override
+    public boolean get(int x, int y, int z)
+    {
+        BlockMatchingChunk chunk = blockMatchingChunks.get(blockToChunkPos(x, z));
+        if(chunk == null)
+            return false;
+        return chunk.getMatchChunk().get(x, y, z);
+    }
+
+    @Override
+    public void set(int x, int y, int z)
+    {
+        BlockMatchingChunk chunk = blockMatchingChunks.get(blockToChunkPos(x, z));
+        if(chunk == null)
+            throw new IllegalArgumentException("Setting bit in absent chunk");
+        chunk.getMatchChunk().set(x, y, z);
+    }
+
+    @Override
+    public void unset(int x, int y, int z)
+    {
+        BlockMatchingChunk chunk = blockMatchingChunks.get(blockToChunkPos(x, z));
+        if(chunk == null)
+            throw new IllegalArgumentException("Unsetting bit in absent chunk");
+        chunk.getMatchChunk().unset(x, y, z);
+    }
+
+    public boolean hasChunk(long chunkPos)
+    {
+        return blockMatchingChunks.containsKey(chunkPos);
+    }
+
+    public @NotNull BlockMatchingChunk addChunk(Chunk chunk, Predicate<Block> blockMatcher)
+    {
+        BlockMatchingChunk matching = new BlockMatchingChunk(this, chunk, matchChunkSupplier, blockMatcher);
+        blockMatchingChunks.put(chunk.getPos().toLong(), matching);
+        return matching;
+    }
+
+    public @Nullable BlockMatchingChunk getChunk(long chunkPos)
+    {
+        return blockMatchingChunks.get(chunkPos);
+    }
+
+    public void removeChunk(long chunkPos)
+    {
+        blockMatchingChunks.get(chunkPos).close();
+        blockMatchingChunks.remove(chunkPos);
+    }
+
+    public Set<Map.Entry<Long, BlockMatchingChunk>> chunkEntries()
+    {
+        return blockMatchingChunks.entrySet();
+    }
+
+    public Collection<BlockMatchingChunk> chunks()
+    {
+        return blockMatchingChunks.values();
+    }
+}

--- a/src/main/java/net/wurstclient/util/world/BoolChunk.java
+++ b/src/main/java/net/wurstclient/util/world/BoolChunk.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util.world;
+
+import org.jetbrains.annotations.Contract;
+
+/**
+ * Specialization of a {@link BoolView} to represent a single Minecraft
+ * {@link net.minecraft.world.chunk.Chunk}'s worth of boolean values.
+ */
+public interface BoolChunk extends BoolView
+{
+    int WIDTH = 16;
+    int HEIGHT = 256;
+    int LENGTH = 16;
+
+    /**
+     * @return `true` if not bits are set in this chunk.
+     */
+    @Contract(pure = true)
+    boolean isEmpty();
+
+    /**
+     * Get an estimation of how many bits are set.
+     * @return A maximum boundary of bits set in this chunk.
+     */
+    @Contract(pure = true)
+    int getBitsSetAtLeastOnce();
+}

--- a/src/main/java/net/wurstclient/util/world/BoolView.java
+++ b/src/main/java/net/wurstclient/util/world/BoolView.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util.world;
+
+import net.minecraft.util.math.BlockPos;
+import net.wurstclient.util.ChunkSearcher;
+import org.jetbrains.annotations.Contract;
+
+/**
+ * Interface to a 3D grid of boolean values.
+ * Used for block-matching hacks' result sets.
+ */
+public interface BoolView extends ChunkSearcher.MatchContainer
+{
+    @Contract(mutates = "this")
+    void clear();
+
+    @Contract(pure = true)
+    boolean get(int x, int y, int z);
+
+    @Contract(pure = true)
+    default boolean get(long blockPos)
+    {
+        return get(
+                BlockPos.unpackLongX(blockPos),
+                BlockPos.unpackLongY(blockPos),
+                BlockPos.unpackLongZ(blockPos));
+    }
+
+    @Contract(mutates = "this")
+    void set(int x, int y, int z);
+
+    @Contract(mutates = "this")
+    default void set(long blockPos)
+    {
+        set(
+                BlockPos.unpackLongX(blockPos),
+                BlockPos.unpackLongY(blockPos),
+                BlockPos.unpackLongZ(blockPos));
+    }
+
+    @Contract(mutates = "this")
+    void unset(int x, int y, int z);
+
+    @Contract(mutates = "this")
+    default void unset(long blockPos)
+    {
+        set(
+                BlockPos.unpackLongX(blockPos),
+                BlockPos.unpackLongY(blockPos),
+                BlockPos.unpackLongZ(blockPos));
+    }
+
+    @Contract(mutates = "this")
+    default void set(int x, int y, int z, boolean value)
+    {
+        if(value)
+        {
+            set(x, y, z);
+        }else
+        {
+            unset(x, y, z);
+        }
+    }
+
+    @Contract(mutates = "this")
+    default void set(long blockPos, boolean value)
+    {
+        set(
+                BlockPos.unpackLongX(blockPos),
+                BlockPos.unpackLongY(blockPos),
+                BlockPos.unpackLongZ(blockPos),
+                value);
+    }
+}

--- a/src/main/java/net/wurstclient/util/world/SetBoolChunk.java
+++ b/src/main/java/net/wurstclient/util/world/SetBoolChunk.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2014-2021 Wurst-Imperium and contributors.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+package net.wurstclient.util.world;
+
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Contract;
+
+import java.util.Set;
+
+/**
+ * Implementation of a {@link BoolChunk} that stores the matched block
+ * positions in a set.
+ * This is the best structure for quickly iterating over a sparse set of
+ * matched blocks (e.g. finding diamonds), but it isn't space efficient as it
+ * stores a 64-bit packed block position for each match; for bulk matching
+ * see {@link ArrayBoolChunk}.
+ */
+public class SetBoolChunk implements BoolChunk
+{
+    private final Set<Long> values = new LongArraySet();
+
+    public SetBoolChunk()
+    {
+        clear();
+    }
+
+    @Contract(mutates = "this")
+    @Override
+    public void clear()
+    {
+        values.clear();
+    }
+
+    @Contract(pure = true)
+    @Override
+    public boolean get(int x, int y, int z)
+    {
+        return values.contains(BlockPos.asLong(x, y, z));
+    }
+
+    @Contract(mutates = "this")
+    @Override
+    public void set(int x, int y, int z)
+    {
+        values.add(BlockPos.asLong(x, y, z));
+    }
+
+    @Contract(mutates = "this")
+    @Override
+    public void unset(int x, int y, int z)
+    {
+        values.remove(BlockPos.asLong(x, y, z));
+    }
+
+    @Contract(pure = true)
+    @Override
+    public int getBitsSetAtLeastOnce()
+    {
+        return values.size();
+    }
+
+    @Contract(pure = true)
+    @Override
+    public boolean isEmpty()
+    {
+        return values.isEmpty();
+    }
+
+    public Set<Long> getBlockPositions()
+    {
+        return values;
+    }
+}

--- a/src/main/resources/assets/wurst/lang/en_us.json
+++ b/src/main/resources/assets/wurst/lang/en_us.json
@@ -102,6 +102,7 @@
   "description.wurst.hack.overlay": "Renders the Nuker animation whenever you mine a block.",
   "description.wurst.hack.panic": "Instantly turns off all enabled hacks.\nBe careful with this one!",
   "description.wurst.hack.parkour": "Makes you jump automatically when reaching the edge of a block.\nUseful for parkours and jump'n'runs.",
+  "description.wurst.hack.portalfinder": "Helps you find active nether portals.",
   "description.wurst.hack.playeresp": "Highlights nearby players.\nESP boxes of friends will appear in blue.",
   "description.wurst.hack.playerfinder": "Finds far away players during thunderstorms.",
   "description.wurst.hack.portalgui": "Allows you to open GUIs in portals.",


### PR DESCRIPTION
## Original PR #496

## Description
[ElementW](https://github.com/ElementW/Wurst7/):
This PR entirely reworks the code used by hacks that match blocks in the world, i.e. BaseFinder, CaveFinder, Search, and introduces a self-explanatory PortalFinder.

The code between the previously mentioned hacks is now gathered in a common BlockMatchHack base class, and introduces a new set of classes in net.wurstclient.util.world to store the block matching state and vertex buffers.
