### PR TITLE
Fix ItemEspHack tracers being janky at high coords

### DIFF
--- a/src/main/java/net/wurstclient/hacks/ItemEspHack.java
+++ b/src/main/java/net/wurstclient/hacks/ItemEspHack.java
@@ -176,21 +176,20 @@ public final class ItemEspHack extends Hack implements UpdateListener,
 		RenderSystem.setShader(GameRenderer::getPositionShader);
 		
 		Vec3d start =
-			RotationUtils.getClientLookVec().add(RenderUtils.getCameraPos());
+			RotationUtils.getClientLookVec().add(RenderUtils.getCameraPos().subtract(regionX, 0, regionZ));
 		
 		bufferBuilder.begin(VertexFormat.DrawMode.DEBUG_LINES,
 			VertexFormats.POSITION);
 		for(ItemEntity e : items)
 		{
 			Vec3d end = e.getBoundingBox().getCenter()
+				.subtract(regionX, 0, regionZ)
 				.subtract(new Vec3d(e.getX(), e.getY(), e.getZ())
 					.subtract(e.prevX, e.prevY, e.prevZ)
 					.multiply(1 - partialTicks));
 			
-			bufferBuilder.vertex(matrix, (float)start.x - regionX,
-				(float)start.y, (float)start.z - regionZ).next();
-			bufferBuilder.vertex(matrix, (float)end.x - regionX, (float)end.y,
-				(float)end.z - regionZ).next();
+			bufferBuilder.vertex(matrix, (float)start.x, (float)start.y, (float)start.z).next();
+			bufferBuilder.vertex(matrix, (float)end.x, (float)end.y, (float)end.z).next();
 		}
 		bufferBuilder.end();
 		BufferRenderer.draw(bufferBuilder);


### PR DESCRIPTION
## Original PR #497

## Description
[ElementW](https://github.com/ElementW/Wurst7/):
Fix janky ItemEspHack tracer positioning when near the 30'000'000 world border.
The problem arises when you do small-scale float math before large-scale (where you lose precision), so this just swaps the math around.

