### PR TITLE
Serverfinder revamp

### DIFF
--- a/src/main/java/net/wurstclient/serverfinder/IPAddress.java
+++ b/src/main/java/net/wurstclient/serverfinder/IPAddress.java
@@ -1,0 +1,97 @@
+package net.wurstclient.serverfinder;
+
+public class IPAddress {
+	
+	private int[] octets;
+	
+	private int port;
+	
+	public IPAddress(int o1, int o2, int o3, int o4, int port) {
+		this.octets = new int[] { o1, o2, o3, o4 };
+		this.port = port;
+	}
+	
+	public IPAddress(int[] octets, int port) {
+		this.octets = octets;
+		this.port = port;
+	}
+	
+	public static IPAddress fromText(String ip) {
+		String[] sections = ip.split(":");
+		if (sections.length < 1 || sections.length > 2)
+			return null;
+		
+		int port = 25565;
+		if (sections.length == 2) {
+			try {
+				port = Integer.parseInt(sections[1].trim());
+			}
+			catch (NumberFormatException e) {
+				return null;
+			}
+		}
+		
+		int[] octets = new int[4];
+		
+		String[] address = sections[0].trim().split("\\.");
+		if (address.length != 4)
+			return null;
+		
+		for (int i = 0; i < 4; i++) {
+			try {
+				octets[i] = Integer.parseInt(address[i].trim());
+			}
+			catch (NumberFormatException e) {
+				return null;
+			}
+		}
+		
+		return new IPAddress(octets, port);
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof IPAddress))
+			return false;
+		
+		IPAddress other = (IPAddress)o;
+		
+		if (octets.length != other.octets.length)
+			return false;
+		
+		if (port != other.port)
+			return false;
+		
+		for (int i = 0; i < octets.length; i++)
+			if (octets[i] != other.octets[i])
+				return false;
+		
+		return true;
+	}
+	
+	@Override
+	public int hashCode() {
+		assert (octets.length == 4);
+		
+		int hash = 43;
+		hash = hash * 59 + octets[0];
+		hash = hash * 83 + octets[1];
+		hash = hash * 71 + octets[2];
+		hash = hash * 17 + octets[3];
+		hash = hash * 31 + port;
+		return hash;
+	}
+	
+	@Override
+	public String toString() {
+		if (octets.length == 0)
+			return null;
+		
+		String result = "" + octets[0];
+		for (int i = 1; i < octets.length; i++) {
+			result += "." + octets[i];
+		}
+		result += ":" + port;
+		return result;
+	}
+}

--- a/src/main/java/net/wurstclient/serverfinder/IServerFinderDisconnectListener.java
+++ b/src/main/java/net/wurstclient/serverfinder/IServerFinderDisconnectListener.java
@@ -1,0 +1,9 @@
+package net.wurstclient.serverfinder;
+
+public interface IServerFinderDisconnectListener {
+	
+	public void onServerDisconnect();
+	
+	public void onServerFailed();
+	
+}

--- a/src/main/java/net/wurstclient/serverfinder/IServerFinderDoneListener.java
+++ b/src/main/java/net/wurstclient/serverfinder/IServerFinderDoneListener.java
@@ -1,0 +1,9 @@
+package net.wurstclient.serverfinder;
+
+public interface IServerFinderDoneListener {
+	
+	public void onServerDone(WurstServerPinger pinger);
+	
+	public void onServerFailed(WurstServerPinger pinger);
+	
+}

--- a/src/main/java/net/wurstclient/serverfinder/ServerFinderScreen.java
+++ b/src/main/java/net/wurstclient/serverfinder/ServerFinderScreen.java
@@ -246,7 +246,8 @@ public class ServerFinderScreen extends Screen implements IServerFinderDoneListe
 		synchronized (serverFinderLock) {
 			if (ipsToPing.size() > 0) {
 				String ip = ipsToPing.pop();
-				WurstServerPinger pinger = new WurstServerPinger(this, scanPorts, searchNumber);
+				WurstServerPinger pinger = new WurstServerPinger(scanPorts, searchNumber);
+				pinger.addServerFinderDoneListener(this);
 				pinger.ping(ip);
 				numActiveThreads++;
 				return true;

--- a/src/main/java/net/wurstclient/serverfinder/ServerFinderScreen.java
+++ b/src/main/java/net/wurstclient/serverfinder/ServerFinderScreen.java
@@ -10,6 +10,7 @@ package net.wurstclient.serverfinder;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Stack;
 
 import org.lwjgl.glfw.GLFW;
 
@@ -24,258 +25,302 @@ import net.minecraft.util.Util;
 import net.wurstclient.mixinterface.IMultiplayerScreen;
 import net.wurstclient.util.MathUtils;
 
-public class ServerFinderScreen extends Screen
-{
+public class ServerFinderScreen extends Screen implements IServerFinderDoneListener {
 	private MultiplayerScreen prevScreen;
-	
+
 	private TextFieldWidget ipBox;
+	private TextFieldWidget versionBox;
 	private TextFieldWidget maxThreadsBox;
 	private ButtonWidget searchButton;
-	
+
 	private ServerFinderState state;
 	private int maxThreads;
-	private int checked;
-	private int working;
+	private volatile int numActiveThreads;
+	private volatile int checked;
+	private volatile int working;
+
+	private int targetChecked = 1792;
+
+	private Stack<String> ipsToPing = new Stack<>();
+
+	private final Object serverFinderLock = new Object();
 	
-	public ServerFinderScreen(MultiplayerScreen prevMultiplayerMenu)
-	{
+	public static ServerFinderScreen instance = null;
+	
+	private ArrayList<String> versionFilters = new ArrayList<>();
+	private int playerCountFilter = 0;
+	private boolean scanPorts = true;
+
+	public ServerFinderScreen(MultiplayerScreen prevMultiplayerMenu) {
 		super(new LiteralText(""));
+		instance = this;
 		prevScreen = prevMultiplayerMenu;
 	}
 	
+	public void incrementTargetChecked(int amount) {
+		synchronized(serverFinderLock) {
+			if (state != ServerFinderState.CANCELLED)
+				targetChecked += amount;
+		}
+	}
+	
+	public ServerFinderState getState() {
+		return state;
+	}
+
 	@Override
-	public void init()
-	{
-		addButton(searchButton =
-			new ButtonWidget(width / 2 - 100, height / 4 + 96 + 12, 200, 20,
+	public void init() {
+		addButton(searchButton = new ButtonWidget(width / 2 - 100, height / 4 + 140 + 12, 200, 20,
 				new LiteralText("Search"), b -> searchOrCancel()));
+
+		addButton(new ButtonWidget(width / 2 - 100, height / 4 + 164 + 12, 200, 20, new LiteralText("Tutorial"),
+				b -> Util.getOperatingSystem()
+						.open("https://www.wurstclient.net/wiki/Special_Features/Server_Finder/")));
+
+		addButton(new ButtonWidget(width / 2 - 100, height / 4 + 188 + 12, 200, 20, new LiteralText("Back"),
+				b -> client.openScreen(prevScreen)));
 		
-		addButton(new ButtonWidget(width / 2 - 100, height / 4 + 120 + 12, 200,
-			20, new LiteralText("Tutorial"),
-			b -> Util.getOperatingSystem().open(
-				"https://www.wurstclient.net/wiki/Special_Features/Server_Finder/")));
+		addButton(new ButtonWidget(width / 2 - 100, height / 4 + 80 + 12, 200, 20, new LiteralText("Scan Ports: " + (scanPorts ? "Yes" : "No")),
+				b -> b.setMessage(new LiteralText("Scan Ports: " + ((scanPorts = !scanPorts) ? "Yes" : "No")))));
 		
-		addButton(new ButtonWidget(width / 2 - 100, height / 4 + 144 + 12, 200,
-			20, new LiteralText("Back"), b -> client.openScreen(prevScreen)));
+		versionBox = new TextFieldWidget(textRenderer, width / 2 - 100, height / 4 + 116 + 12, 200, 20, new LiteralText(""));
+		versionBox.setMaxLength(200);
+		versionBox.setText("1.16.5; 1.16.4");
+		children.add(versionBox);
 		
-		ipBox = new TextFieldWidget(textRenderer, width / 2 - 100,
-			height / 4 + 34, 200, 20, new LiteralText(""));
+		ipBox = new TextFieldWidget(textRenderer, width / 2 - 100, height / 4 + 14, 200, 20, new LiteralText(""));
 		ipBox.setMaxLength(200);
 		ipBox.setSelected(true);
 		children.add(ipBox);
-		
-		maxThreadsBox = new TextFieldWidget(textRenderer, width / 2 - 32,
-			height / 4 + 58, 26, 12, new LiteralText(""));
+
+		maxThreadsBox = new TextFieldWidget(textRenderer, width / 2 - 32, height / 4 + 38, 26, 12, new LiteralText(""));
 		maxThreadsBox.setMaxLength(3);
 		maxThreadsBox.setText("128");
 		children.add(maxThreadsBox);
-		
+
 		setInitialFocus(ipBox);
 		state = ServerFinderState.NOT_RUNNING;
 	}
-	
-	private void searchOrCancel()
-	{
-		if(state.isRunning())
-		{
+
+	private void searchOrCancel() {
+		if (state.isRunning()) {
 			state = ServerFinderState.CANCELLED;
 			return;
 		}
-		
+
 		state = ServerFinderState.RESOLVING;
 		maxThreads = Integer.parseInt(maxThreadsBox.getText());
+		numActiveThreads = 0;
 		checked = 0;
 		working = 0;
-		
-		new Thread(() -> findServers(), "Server Finder").start();
+
+		findServers();
 	}
 	
-	private void findServers()
-	{
-		try
-		{
-			InetAddress addr =
-				InetAddress.getByName(ipBox.getText().split(":")[0].trim());
-			
+	private void parseVersionFilters() {
+		String filter = versionBox.getText();
+		String[] versions = filter.split(";");
+		if (versionFilters == null) {
+			versionFilters = new ArrayList<>();
+		}
+		versionFilters.clear();
+		for (String version : versions) {
+			String trimmed = version.trim();
+			if (trimmed.length() > 0)
+				versionFilters.add(version.trim());
+		}
+	}
+
+	private void findServers() {
+		parseVersionFilters();
+		try {
+			InetAddress addr = InetAddress.getByName(ipBox.getText().split(":")[0].trim());
+
 			int[] ipParts = new int[4];
-			for(int i = 0; i < 4; i++)
+			for (int i = 0; i < 4; i++)
 				ipParts[i] = addr.getAddress()[i] & 0xff;
-			
+
 			state = ServerFinderState.SEARCHING;
-			ArrayList<WurstServerPinger> pingers = new ArrayList<>();
-			int[] changes = {0, 1, -1, 2, -2, 3, -3};
-			for(int change : changes)
-				for(int i2 = 0; i2 <= 255; i2++)
-				{
-					if(state == ServerFinderState.CANCELLED)
+			int[] changes = { 0, 1, -1, 2, -2, 3, -3 };
+			for (int change : changes)
+				for (int i2 = 0; i2 <= 255; i2++) {
+					if (state == ServerFinderState.CANCELLED)
 						return;
-					
+
 					int[] ipParts2 = ipParts.clone();
 					ipParts2[2] = ipParts[2] + change & 0xff;
 					ipParts2[3] = i2;
-					String ip = ipParts2[0] + "." + ipParts2[1] + "."
-						+ ipParts2[2] + "." + ipParts2[3];
-					
-					WurstServerPinger pinger = new WurstServerPinger();
-					pinger.ping(ip);
-					pingers.add(pinger);
-					while(pingers.size() >= maxThreads)
-					{
-						if(state == ServerFinderState.CANCELLED)
-							return;
-						
-						updatePingers(pingers);
-					}
+					String ip = ipParts2[0] + "." + ipParts2[1] + "." + ipParts2[2] + "." + ipParts2[3];
+
+					ipsToPing.push(ip);
 				}
-			while(pingers.size() > 0)
-			{
-				if(state == ServerFinderState.CANCELLED)
-					return;
-				
-				updatePingers(pingers);
+			while (numActiveThreads < maxThreads && pingNewIP()) {
 			}
-			state = ServerFinderState.DONE;
-			
-		}catch(UnknownHostException e)
-		{
+
+		} catch (UnknownHostException e) {
 			state = ServerFinderState.UNKNOWN_HOST;
-			
-		}catch(Exception e)
-		{
+
+		} catch (Exception e) {
 			e.printStackTrace();
 			state = ServerFinderState.ERROR;
 		}
 	}
-	
-	@Override
-	public void tick()
-	{
-		ipBox.tick();
-		
-		searchButton.setMessage(
-			new LiteralText(state.isRunning() ? "Cancel" : "Search"));
-		ipBox.active = !state.isRunning();
-		maxThreadsBox.active = !state.isRunning();
-		
-		searchButton.active = MathUtils.isInteger(maxThreadsBox.getText())
-			&& !ipBox.getText().isEmpty();
-	}
-	
-	private boolean isServerInList(String ip)
-	{
-		for(int i = 0; i < prevScreen.getServerList().size(); i++)
-			if(prevScreen.getServerList().get(i).address.equals(ip))
+
+	private boolean pingNewIP() {
+		synchronized (serverFinderLock) {
+			if (ipsToPing.size() > 0) {
+				String ip = ipsToPing.pop();
+				WurstServerPinger pinger = new WurstServerPinger(this, scanPorts);
+				pinger.ping(ip);
+				numActiveThreads++;
 				return true;
-			
+			}
+		}
 		return false;
 	}
-	
-	private void updatePingers(ArrayList<WurstServerPinger> pingers)
-	{
-		for(int i = 0; i < pingers.size(); i++)
-			if(!pingers.get(i).isStillPinging())
-			{
-				checked++;
-				if(pingers.get(i).isWorking())
-				{
-					working++;
-					
-					if(!isServerInList(pingers.get(i).getServerIP()))
-					{
-						prevScreen.getServerList()
-							.add(new ServerInfo("Grief me #" + working,
-								pingers.get(i).getServerIP(), false));
-						prevScreen.getServerList().saveFile();
-						((IMultiplayerScreen)prevScreen).getServerListSelector()
-							.setSelected(null);
-						((IMultiplayerScreen)prevScreen).getServerListSelector()
-							.setServers(prevScreen.getServerList());
-					}
-				}
-				pingers.remove(i);
-			}
-	}
-	
+
 	@Override
-	public boolean keyPressed(int keyCode, int scanCode, int int_3)
-	{
-		if(keyCode == GLFW.GLFW_KEY_ENTER)
+	public void tick() {
+		ipBox.tick();
+		versionBox.tick();
+
+		searchButton.setMessage(new LiteralText(state.isRunning() ? "Cancel" : "Search"));
+		ipBox.active = !state.isRunning();
+		versionBox.active = !state.isRunning();
+		maxThreadsBox.active = !state.isRunning();
+
+		searchButton.active = MathUtils.isInteger(maxThreadsBox.getText()) && !ipBox.getText().isEmpty();
+	}
+
+	private boolean isServerInList(String ip) {
+		for (int i = 0; i < prevScreen.getServerList().size(); i++)
+			if (prevScreen.getServerList().get(i).address.equals(ip))
+				return true;
+
+		return false;
+	}
+
+	@Override
+	public boolean keyPressed(int keyCode, int scanCode, int int_3) {
+		if (keyCode == GLFW.GLFW_KEY_ENTER)
 			searchButton.onPress();
-		
+
 		return super.keyPressed(keyCode, scanCode, int_3);
 	}
-	
+
 	@Override
-	public void render(MatrixStack matrixStack, int mouseX, int mouseY,
-		float partialTicks)
-	{
+	public void render(MatrixStack matrixStack, int mouseX, int mouseY, float partialTicks) {
 		renderBackground(matrixStack);
-		
-		drawCenteredString(matrixStack, textRenderer, "Server Finder",
-			width / 2, 20, 16777215);
-		drawCenteredString(matrixStack, textRenderer,
-			"This will search for servers with similar IPs", width / 2, 40,
-			10526880);
-		drawCenteredString(matrixStack, textRenderer,
-			"to the IP you type into the field below.", width / 2, 50,
-			10526880);
-		drawCenteredString(matrixStack, textRenderer,
-			"The servers it finds will be added to your server list.",
-			width / 2, 60, 10526880);
-		
-		drawStringWithShadow(matrixStack, textRenderer, "Server address:",
-			width / 2 - 100, height / 4 + 24, 10526880);
+
+		drawCenteredString(matrixStack, textRenderer, "Server Finder", width / 2, 20, 16777215);
+		drawCenteredString(matrixStack, textRenderer, "This will search for servers with similar IPs", width / 2, 40,
+				10526880);
+		drawCenteredString(matrixStack, textRenderer, "to the IP you type into the field below.", width / 2, 50,
+				10526880);
+		drawCenteredString(matrixStack, textRenderer, "The servers it finds will be added to your server list.",
+				width / 2, 60, 10526880);
+
+		drawStringWithShadow(matrixStack, textRenderer, "Server address:", width / 2 - 100, height / 4 + 4, 10526880);
 		ipBox.render(matrixStack, mouseX, mouseY, partialTicks);
 		
-		drawStringWithShadow(matrixStack, textRenderer, "Max. threads:",
-			width / 2 - 100, height / 4 + 60, 10526880);
+		drawStringWithShadow(matrixStack, textRenderer, "Filter by version:", width / 2 - 100, height / 4 + 106 + 12, 10526880);
+		versionBox.render(matrixStack, mouseX, mouseY, partialTicks);
+		
+		drawStringWithShadow(matrixStack, textRenderer, "Max. threads:", width / 2 - 100, height / 4 + 40, 10526880);
 		maxThreadsBox.render(matrixStack, mouseX, mouseY, partialTicks);
-		
-		drawCenteredString(matrixStack, textRenderer, state.toString(),
-			width / 2, height / 4 + 73, 10526880);
-		
-		drawStringWithShadow(matrixStack, textRenderer,
-			"Checked: " + checked + " / 1792", width / 2 - 100, height / 4 + 84,
-			10526880);
-		drawStringWithShadow(matrixStack, textRenderer, "Working: " + working,
-			width / 2 - 100, height / 4 + 94, 10526880);
-		
+
+		drawCenteredString(matrixStack, textRenderer, state.toString(), width / 2, height / 4 + 53, 10526880);
+
+		drawStringWithShadow(matrixStack, textRenderer, "Checked: " + checked + " / " + targetChecked, width / 2 - 100,
+				height / 4 + 64, 10526880);
+		drawStringWithShadow(matrixStack, textRenderer, "Working: " + working, width / 2 - 100, height / 4 + 74,
+				10526880);
+
 		super.render(matrixStack, mouseX, mouseY, partialTicks);
 	}
-	
+
 	@Override
-	public void onClose()
-	{
+	public void onClose() {
 		state = ServerFinderState.CANCELLED;
 		super.onClose();
 	}
-	
-	enum ServerFinderState
-	{
-		NOT_RUNNING(""),
-		SEARCHING("\u00a72Searching..."),
-		RESOLVING("\u00a72Resolving..."),
-		UNKNOWN_HOST("\u00a74Unknown Host!"),
-		CANCELLED("\u00a74Cancelled!"),
-		DONE("\u00a72Done!"),
+
+	enum ServerFinderState {
+		NOT_RUNNING(""), SEARCHING("\u00a72Searching..."), RESOLVING("\u00a72Resolving..."),
+		UNKNOWN_HOST("\u00a74Unknown Host!"), CANCELLED("\u00a74Cancelled!"), DONE("\u00a72Done!"),
 		ERROR("\u00a74An error occurred!");
-		
+
 		private final String name;
-		
-		private ServerFinderState(String name)
-		{
+
+		private ServerFinderState(String name) {
 			this.name = name;
 		}
-		
-		public boolean isRunning()
-		{
+
+		public boolean isRunning() {
 			return this == SEARCHING || this == RESOLVING;
 		}
-		
+
 		@Override
-		public String toString()
-		{
+		public String toString() {
 			return name;
+		}
+	}
+	
+	private boolean filterPass(WurstServerInfo info) {
+		if (info == null)
+			return false;
+		if (info.playerCount < playerCountFilter)
+			return false;
+		for (String version : versionFilters) {
+			if (info.version != null && info.version.contains(version)) {
+				return true;
+			}
+		}
+		return versionFilters.isEmpty();
+	}
+	
+	@Override
+	public void onServerDone(WurstServerPinger pinger) {
+		if (state == ServerFinderState.CANCELLED)
+			return;
+		synchronized (serverFinderLock) {
+			checked++;
+			numActiveThreads--;
+		}
+		if (pinger.isWorking()) {
+			if (!isServerInList(pinger.getServerIP()) && filterPass(pinger.getServerInfo())) {
+				synchronized (serverFinderLock) {
+					working++;
+					prevScreen.getServerList().add(new ServerInfo("Grief me #" + working, pinger.getServerIP(), false));
+					prevScreen.getServerList().saveFile();
+					((IMultiplayerScreen) prevScreen).getServerListSelector().setSelected(null);
+					((IMultiplayerScreen) prevScreen).getServerListSelector().setServers(prevScreen.getServerList());
+				}
+			}
+		}
+		while (numActiveThreads < maxThreads && pingNewIP()) {
+		}
+		synchronized (serverFinderLock) {
+			if (checked == targetChecked) {
+				state = ServerFinderState.DONE;
+			}
+		}
+	}
+
+	@Override
+	public void onServerFailed(WurstServerPinger pinger) {
+		if (state == ServerFinderState.CANCELLED)
+			return;
+		synchronized (serverFinderLock) {
+			checked++;
+			numActiveThreads--;
+		}
+		while (numActiveThreads < maxThreads && pingNewIP()) {
+		}
+		synchronized (serverFinderLock) {
+			if (checked == targetChecked) {
+				state = ServerFinderState.DONE;
+			}
 		}
 	}
 }

--- a/src/main/java/net/wurstclient/serverfinder/WurstServerInfo.java
+++ b/src/main/java/net/wurstclient/serverfinder/WurstServerInfo.java
@@ -1,0 +1,120 @@
+package net.wurstclient.serverfinder;
+
+import java.util.Collections;
+import java.util.List;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.SharedConstants;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import org.jetbrains.annotations.Nullable;
+
+@Environment(EnvType.CLIENT)
+public class WurstServerInfo {
+   public String name;
+   public String address;
+   public String playerCountLabel;
+   public int playerCount;
+   public int playercountMax;
+   public String label;
+   public long ping;
+   public int protocolVersion = SharedConstants.getGameVersion().getProtocolVersion();
+   public String version = null;
+   public boolean online;
+   public List<Text> playerListSummary = Collections.emptyList();
+   private WurstServerInfo.ResourcePackState resourcePackState;
+   @Nullable
+   private String icon;
+   private boolean local;
+
+   public WurstServerInfo(String name, String address, boolean local) {
+      this.resourcePackState = WurstServerInfo.ResourcePackState.PROMPT;
+      this.name = name;
+      this.address = address;
+      this.local = local;
+   }
+
+   public CompoundTag serialize() {
+      CompoundTag compoundTag = new CompoundTag();
+      compoundTag.putString("name", this.name);
+      compoundTag.putString("ip", this.address);
+      if (this.icon != null) {
+         compoundTag.putString("icon", this.icon);
+      }
+
+      if (this.resourcePackState == WurstServerInfo.ResourcePackState.ENABLED) {
+         compoundTag.putBoolean("acceptTextures", true);
+      } else if (this.resourcePackState == WurstServerInfo.ResourcePackState.DISABLED) {
+         compoundTag.putBoolean("acceptTextures", false);
+      }
+
+      return compoundTag;
+   }
+
+   public WurstServerInfo.ResourcePackState getResourcePack() {
+      return this.resourcePackState;
+   }
+
+   public void setResourcePackState(WurstServerInfo.ResourcePackState resourcePackState) {
+      this.resourcePackState = resourcePackState;
+   }
+
+   public static WurstServerInfo deserialize(CompoundTag tag) {
+      WurstServerInfo serverInfo = new WurstServerInfo(tag.getString("name"), tag.getString("ip"), false);
+      if (tag.contains("icon", 8)) {
+         serverInfo.setIcon(tag.getString("icon"));
+      }
+
+      if (tag.contains("acceptTextures", 1)) {
+         if (tag.getBoolean("acceptTextures")) {
+            serverInfo.setResourcePackState(WurstServerInfo.ResourcePackState.ENABLED);
+         } else {
+            serverInfo.setResourcePackState(WurstServerInfo.ResourcePackState.DISABLED);
+         }
+      } else {
+         serverInfo.setResourcePackState(WurstServerInfo.ResourcePackState.PROMPT);
+      }
+
+      return serverInfo;
+   }
+
+   @Nullable
+   public String getIcon() {
+      return this.icon;
+   }
+
+   public void setIcon(@Nullable String string) {
+      this.icon = string;
+   }
+
+   public boolean isLocal() {
+      return this.local;
+   }
+
+   public void copyFrom(WurstServerInfo serverInfo) {
+      this.address = serverInfo.address;
+      this.name = serverInfo.name;
+      this.setResourcePackState(serverInfo.getResourcePack());
+      this.icon = serverInfo.icon;
+      this.local = serverInfo.local;
+   }
+
+   @Environment(EnvType.CLIENT)
+   public static enum ResourcePackState {
+      ENABLED("enabled"),
+      DISABLED("disabled"),
+      PROMPT("prompt");
+
+      private final Text name;
+
+      private ResourcePackState(String name) {
+         this.name = new TranslatableText("addServer.resourcePack." + name);
+      }
+
+      public Text getName() {
+         return this.name;
+      }
+   }
+}

--- a/src/main/java/net/wurstclient/serverfinder/WurstServerListPinger.java
+++ b/src/main/java/net/wurstclient/serverfinder/WurstServerListPinger.java
@@ -1,0 +1,317 @@
+package net.wurstclient.serverfinder;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.mojang.authlib.GameProfile;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelException;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.NetworkState;
+import net.minecraft.network.ServerAddress;
+import net.minecraft.network.listener.ClientQueryPacketListener;
+import net.minecraft.network.packet.c2s.handshake.HandshakeC2SPacket;
+import net.minecraft.network.packet.c2s.query.QueryPingC2SPacket;
+import net.minecraft.network.packet.c2s.query.QueryRequestC2SPacket;
+import net.minecraft.network.packet.s2c.query.QueryPongS2CPacket;
+import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket;
+import net.minecraft.server.ServerMetadata;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.MathHelper;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Environment(EnvType.CLIENT)
+public class WurstServerListPinger {
+   private static final Splitter ZERO_SPLITTER = Splitter.on('\u0000').limit(6);
+   private static final Logger LOGGER = LogManager.getLogger();
+   private final List<ClientConnection> clientConnections = Collections.synchronizedList(Lists.newArrayList());
+   private ArrayList<IServerFinderDisconnectListener> disconnectListeners = new ArrayList<>();
+   private boolean notifiedDisconnectListeners = false;
+   private boolean failedToConnect = true;
+   
+   public void addServerFinderDisconnectListener(IServerFinderDisconnectListener listener) {
+	   disconnectListeners.add(listener);
+   }
+   
+   private void notifyDisconnectListeners() {
+	   synchronized(this) {
+		   if (!notifiedDisconnectListeners) {
+			   notifiedDisconnectListeners = true;
+			   for (IServerFinderDisconnectListener l : disconnectListeners) {
+				   if (l != null) {
+			    	   if (failedToConnect) {
+			    		   l.onServerFailed();
+			    	   }
+			    	   else {
+			    		   l.onServerDisconnect();
+			    	   }
+				   }
+		       }
+		   }
+	   }
+   }
+   
+   public void add(final WurstServerInfo entry, final Runnable runnable) throws UnknownHostException {
+	  WurstServerListPinger thisPinger = this;
+	  Timer timeoutTimer = new Timer();
+      ServerAddress serverAddress = ServerAddress.parse(entry.address);
+      timeoutTimer.schedule(new TimerTask() {
+    	  @Override
+    	  public void run() {
+    		  notifyDisconnectListeners();
+    	  }
+      }, 20000);
+      final ClientConnection clientConnection = ClientConnection.connect(InetAddress.getByName(serverAddress.getAddress()), serverAddress.getPort(), false);
+      failedToConnect = false;
+      this.clientConnections.add(clientConnection);
+      entry.label = "multiplayer.status.pinging";
+      entry.ping = -1L;
+      entry.playerListSummary = null;
+      clientConnection.setPacketListener(new ClientQueryPacketListener() {
+         private boolean sentQuery;
+         private boolean received;
+         private long startTime;
+
+         public void onResponse(QueryResponseS2CPacket packet) {
+            if (this.received) {
+               clientConnection.disconnect(new TranslatableText("multiplayer.status.unrequested"));
+            } else {
+               this.received = true;
+               ServerMetadata serverMetadata = packet.getServerMetadata();
+               if (serverMetadata.getDescription() != null) {
+                  entry.label = serverMetadata.getDescription().asString();
+               } else {
+                  entry.label = "";
+               }
+
+               if (serverMetadata.getVersion() != null) {
+                  entry.version = serverMetadata.getVersion().getGameVersion();
+                  entry.protocolVersion = serverMetadata.getVersion().getProtocolVersion();
+               } else {
+                  entry.version = "multiplayer.status.old";
+                  entry.protocolVersion = 0;
+               }
+
+               if (serverMetadata.getPlayers() != null) {
+                  entry.playerCountLabel = WurstServerListPinger.method_27647(serverMetadata.getPlayers().getOnlinePlayerCount(), serverMetadata.getPlayers().getPlayerLimit());
+                  entry.playerCount = serverMetadata.getPlayers().getOnlinePlayerCount();
+                  entry.playercountMax = serverMetadata.getPlayers().getPlayerLimit();
+                  List<Text> list = Lists.newArrayList();
+                  if (ArrayUtils.isNotEmpty(serverMetadata.getPlayers().getSample())) {
+                     GameProfile[] var4 = serverMetadata.getPlayers().getSample();
+                     int var5 = var4.length;
+
+                     for(int var6 = 0; var6 < var5; ++var6) {
+                        GameProfile gameProfile = var4[var6];
+                        list.add(new LiteralText(gameProfile.getName()));
+                     }
+
+                     if (serverMetadata.getPlayers().getSample().length < serverMetadata.getPlayers().getOnlinePlayerCount()) {
+                        list.add(new TranslatableText("multiplayer.status.and_more", new Object[]{serverMetadata.getPlayers().getOnlinePlayerCount() - serverMetadata.getPlayers().getSample().length}));
+                     }
+
+                     entry.playerListSummary = list;
+                  }
+               } else {
+                  entry.playerCountLabel = "multiplayer.status.unknown";
+               }
+
+               String string = null;
+               if (serverMetadata.getFavicon() != null) {
+                  String string2 = serverMetadata.getFavicon();
+                  if (string2.startsWith("data:image/png;base64,")) {
+                     string = string2.substring("data:image/png;base64,".length());
+                  } else {
+                     WurstServerListPinger.LOGGER.error("Invalid server icon (unknown format)");
+                  }
+               }
+
+               if (!Objects.equals(string, entry.getIcon())) {
+                  entry.setIcon(string);
+                  runnable.run();
+               }
+
+               this.startTime = Util.getMeasuringTimeMs();
+               clientConnection.send(new QueryPingC2SPacket(this.startTime));
+               this.sentQuery = true;
+               notifyDisconnectListeners();
+            }
+         }
+
+         public void onPong(QueryPongS2CPacket packet) {
+            long l = this.startTime;
+            long m = Util.getMeasuringTimeMs();
+            entry.ping = m - l;
+            clientConnection.disconnect(new TranslatableText("multiplayer.status.finished"));
+         }
+
+         public void onDisconnected(Text reason) {
+            if (!this.sentQuery) {
+               WurstServerListPinger.LOGGER.error("Can't ping {}: {}", entry.address, reason.getString());
+               entry.label = "multiplayer.status.cannot_connect";
+               entry.playerCountLabel = "";
+               entry.playerCount = 0;
+               entry.playercountMax = 0;
+               WurstServerListPinger.this.ping(entry);
+            }
+            notifyDisconnectListeners();
+         }
+
+         public ClientConnection getConnection() {
+            return clientConnection;
+         }
+      });
+
+      try {
+         clientConnection.send(new HandshakeC2SPacket(serverAddress.getAddress(), serverAddress.getPort(), NetworkState.STATUS));
+         clientConnection.send(new QueryRequestC2SPacket());
+      } catch (Throwable var6) {
+         LOGGER.error(var6);
+      }
+   }
+
+   private void ping(final WurstServerInfo serverInfo) {
+      final ServerAddress serverAddress = ServerAddress.parse(serverInfo.address);
+      ((Bootstrap)((Bootstrap)((Bootstrap)(new Bootstrap()).group((EventLoopGroup)ClientConnection.CLIENT_IO_GROUP.get())).handler(new ChannelInitializer<Channel>() {
+         protected void initChannel(Channel channel) throws Exception {
+            try {
+               channel.config().setOption(ChannelOption.TCP_NODELAY, true);
+            } catch (ChannelException var3) {
+            }
+
+            channel.pipeline().addLast(new ChannelHandler[]{new SimpleChannelInboundHandler<ByteBuf>() {
+               public void channelActive(ChannelHandlerContext channelHandlerContext) throws Exception {
+                  super.channelActive(channelHandlerContext);
+                  ByteBuf byteBuf = Unpooled.buffer();
+
+                  try {
+                     byteBuf.writeByte(254);
+                     byteBuf.writeByte(1);
+                     byteBuf.writeByte(250);
+                     char[] cs = "MC|PingHost".toCharArray();
+                     byteBuf.writeShort(cs.length);
+                     char[] var4 = cs;
+                     int var5 = cs.length;
+
+                     int var6;
+                     char d;
+                     for(var6 = 0; var6 < var5; ++var6) {
+                        d = var4[var6];
+                        byteBuf.writeChar(d);
+                     }
+
+                     byteBuf.writeShort(7 + 2 * serverAddress.getAddress().length());
+                     byteBuf.writeByte(127);
+                     cs = serverAddress.getAddress().toCharArray();
+                     byteBuf.writeShort(cs.length);
+                     var4 = cs;
+                     var5 = cs.length;
+
+                     for(var6 = 0; var6 < var5; ++var6) {
+                        d = var4[var6];
+                        byteBuf.writeChar(d);
+                     }
+
+                     byteBuf.writeInt(serverAddress.getPort());
+                     channelHandlerContext.channel().writeAndFlush(byteBuf).addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+                  } finally {
+                     byteBuf.release();
+                  }
+               }
+
+               protected void channelRead0(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf) throws Exception {
+                  short s = byteBuf.readUnsignedByte();
+                  if (s == 255) {
+                     String string = new String(byteBuf.readBytes(byteBuf.readShort() * 2).array(), StandardCharsets.UTF_16BE);
+                     String[] strings = (String[])Iterables.toArray(WurstServerListPinger.ZERO_SPLITTER.split(string), String.class);
+                     if ("§1".equals(strings[0])) {
+                        int i = MathHelper.parseInt(strings[1], 0);
+                        String string2 = strings[2];
+                        String string3 = strings[3];
+                        int j = MathHelper.parseInt(strings[4], -1);
+                        int k = MathHelper.parseInt(strings[5], -1);
+                        serverInfo.protocolVersion = -1;
+                        serverInfo.version = string2;
+                        serverInfo.label = string3;
+                        serverInfo.playerCountLabel = WurstServerListPinger.method_27647(j, k);
+                     }
+                  }
+
+                  channelHandlerContext.close();
+               }
+
+               public void exceptionCaught(ChannelHandlerContext channelHandlerContext, Throwable throwable) throws Exception {
+                  channelHandlerContext.close();
+               }
+            }});
+         }
+      })).channel(NioSocketChannel.class)).connect(serverAddress.getAddress(), serverAddress.getPort());
+   }
+
+   private static String method_27647(int i, int j) {
+      return Integer.toString(i) + "/" + Integer.toString(j);
+   }
+
+   public void tick() {
+      synchronized(this.clientConnections) {
+         Iterator iterator = this.clientConnections.iterator();
+
+         while(iterator.hasNext()) {
+            ClientConnection clientConnection = (ClientConnection)iterator.next();
+            if (clientConnection.isOpen()) {
+               clientConnection.tick();
+            } else {
+               iterator.remove();
+               clientConnection.handleDisconnection();
+            }
+         }
+
+      }
+   }
+
+   public void cancel() {
+      synchronized(this.clientConnections) {
+         Iterator iterator = this.clientConnections.iterator();
+
+         while(iterator.hasNext()) {
+            ClientConnection clientConnection = (ClientConnection)iterator.next();
+            if (clientConnection.isOpen()) {
+               iterator.remove();
+               clientConnection.disconnect(new TranslatableText("multiplayer.status.cancelled"));
+            }
+         }
+
+      }
+   }
+}


### PR DESCRIPTION
## Original PR #319

## Description
[cropbob](https://github.com/cropbob/Wurst7/):
General improvement of server finder netcode and addition of a few new server finder features.

Previously the server finder did not use an event-based pinging system and consequently needed a thread to be constantly spinning and checking for completed pings. This is no longer the case.
The old server finder would also mark pings as done before they had time to fetch server metadata (version, player count, etc). The new event-based system will wait until requests are done fetching the metadata, or until they time out.
Related to the previous point, filtering based on version and player count is now possible. UI has been added for version filtering. Multiple versions can be included in the filter as long as they are separated by semicolons. I didn't add player count filtering because the UI is already packed, but adding it would be trivial.
Many server hosts will not only host sequentially over the last 2 octets of the IP but over ports as well. Port scanning is now available. If selected, it will scan a 200-port range about port 25565 on each scanned IP for which port 25565 is open. This is dependent on the host, but I've seen it lead to as many as 20x as many servers being found.
It is now possible to save the servers in your server list as a plaintext file (servers.txt under the wurst folder in .minecraft) using the "Save to File" button. Duplicate entries are prevented in amortized O(n) time using a hashset. A message is displayed indicating how many new servers were saved to the list. Useful if you want to know whether you've already visited the servers that were found.